### PR TITLE
First round of cosmetics

### DIFF
--- a/xfields/ibs/__init__.py
+++ b/xfields/ibs/__init__.py
@@ -6,7 +6,7 @@
 from ._analytical import BjorkenMtingwaIBS, IBSGrowthRates, NagaitsevIBS
 from ._api import configure_intrabeam_scattering, get_intrabeam_scattering_growth_rates
 from ._kicks import IBSAnalyticalKick, IBSKineticKick
-from ._equilibrium_emittance import ibs_rates, compute_emittance_evolution
+from ._equilibrium_emittance import compute_emittance_evolution
 
 __all__ = [
     "BjorkenMtingwaIBS",

--- a/xfields/ibs/_equilibrium_emittance.py
+++ b/xfields/ibs/_equilibrium_emittance.py
@@ -98,7 +98,17 @@ def _ibs_rates_and_emittance_derivatives(
     # TODO: bunch emittances - ask for the three separately and update docstring
     input_emittance_x, input_emittance_y, input_emittance_z = input_emittances
 
-    # TODO: can check that the SR eq emittances are present in twiss object (or in public func?)
+    # TODO: can check that the SR eq emittances are present in twiss object (or in public func?) Could be:
+    # if None in (
+    #     getattr(twiss, "eq_gemitt_x", None),
+    #     getattr(twiss, "eq_gemitt_y", None),
+    #     getattr(twiss, "eq_gemitt_zeta", None),
+    #     getattr(twiss, "damping_constants_s", None),
+    # ):
+    #     raise AttributeError(
+    #         "The TwissTable must contain SR equilibrium emittances and damping constants. "
+    #         "Did you activate radiation and twiss with eneloss_and_damping=True?"
+    #     )
 
     sigma_zeta = (input_emittance_z * longitudinal_emittance_ratio) ** 0.5
     sigma_delta = (input_emittance_z / longitudinal_emittance_ratio) ** 0.5

--- a/xfields/ibs/_equilibrium_emittance.py
+++ b/xfields/ibs/_equilibrium_emittance.py
@@ -134,15 +134,15 @@ def _ibs_rates_and_emittance_derivatives(
     )
 
     depsilon_x_dt = (
-        -2 * damping_rate_x * (input_emittance_x - natural_emittance_x)
+        -2 * damping_rate_x * (input_emittance_x - twiss.eq_gemitt_x)
         + ibs_growth_rates.Tx * input_emittance_x
     )
     depsilon_y_dt = (
-        -2 * damping_rate_y * (input_emittance_y - natural_emittance_y)
+        -2 * damping_rate_y * (input_emittance_y - twiss.eq_gemitt_y)
         + ibs_growth_rates.Ty * input_emittance_y
     )
     depsilon_z_dt = (
-        -2 * damping_rate_z * (input_emittance_z - natural_emittance_z)
+        -2 * damping_rate_z * (input_emittance_z - twiss.eq_gemitt_zeta)
         + ibs_growth_rates.Tz * input_emittance_z
     )
 

--- a/xfields/ibs/_equilibrium_emittance.py
+++ b/xfields/ibs/_equilibrium_emittance.py
@@ -3,27 +3,70 @@
 # Copyright (c) CERN, 2021.                   #
 # ########################################### #
 
+from __future__ import annotations
+
+import logging
 import sys
 import warnings
-#from logging import getLogger
-from typing import Tuple, Literal
+from typing import Literal
 
 import numpy as np
+import xobjects as xo
 import xtrack as xt
+from xtrack import Table
 
-#LOGGER = getLogger(__name__)
+from xfields.ibs._analytical import IBSGrowthRates
+
+LOGGER = logging.getLogger(__name__)
+
+# ----- Some classes to store results (as xo.HybridClass) ----- #
+
+
+class _EmittanceTimeDerivatives(xo.HybridClass):
+    """
+    Holds emittance evolution rates named ``dex``,
+    ``dey``, and ``dez``. The values are expressed
+    in [m.s^-1].
+
+    Attributes
+    ----------
+    dex : float
+        Horizontal geometric emittance time
+        derivative, in [m.s^-1].
+    dey : float
+        Vertical geometric emittance time
+        derivative, in [m.s^-1].
+    dez : float
+        Longitudinal geometric emittance time
+        derivative, in [m.s^-1].
+    """
+
+    _xofields = {
+        "dex": xo.Float64,
+        "dey": xo.Float64,
+        "dez": xo.Float64,
+    }
+
+    def __init__(self, dex: float, dey: float, dez: float) -> None:
+        """Init with given values."""
+        self.xoinitialize(dex=dex, dey=dey, dez=dez)
+
+    def as_tuple(self) -> tuple[float, float, float]:
+        """Return the growth rates as a tuple."""
+        return float(self.dex), float(self.dey), float(self.dez)
+
 
 def ibs_rates(
     twiss: xt.TwissTable,
     bunch_intensity: float,
-    input_emittances: Tuple,
+    input_emittances: tuple,
     emittance_coupling_factor: float = 0,
     emittance_constraint: Literal["Coupling", "Excitation"] = "Coupling",
     formalism: Literal["Nagaitsev", "Bjorken-Mtingwa", "B&M"] = "Nagaitsev",
     longitudinal_emittance_ratio: float = None,
-    damping_rates: Tuple = None,
+    damping_rates: tuple = None,
     **kwargs,
-):
+) -> tuple[IBSGrowthRates, _EmittanceTimeDerivatives]:
     """
     Compute the IBS growth rates and emittance evolution rates.
 
@@ -34,19 +77,19 @@ def ibs_rates(
     bunch_intensity : float
         Bunch intensity [particles per bunch].
     input_emittances : tuple of floats
-        Tuple containing the equilibrium transverse emittances (horizontal and 
+        Tuple containing the equilibrium transverse emittances (horizontal and
         vertical).
     emittance_coupling_factor : float, optional
-        Emittance coupling factor, defined as the ratio of vertical to 
+        Emittance coupling factor, defined as the ratio of vertical to
         horizontal emittance.
         Default is 0.
     emittance_constraint : str, optional
         Can enforces constraints on the transverse emittance based on the
-        emittance coupling factor. 
+        emittance coupling factor.
         "Coupling" corresponds to the case where the
         vertical emittance is the result of linear coupling.
-        "Excitation" corresponds to the case where the vertical emittance is 
-        the result of an excitation (e.g. from a feedback system). 
+        "Excitation" corresponds to the case where the vertical emittance is
+        the result of an excitation (e.g. from a feedback system).
         Default is "Coupling".
     formalism : str, optional
         Which formalism to use for the computation. Can be ``Nagaitsev``
@@ -76,21 +119,19 @@ def ibs_rates(
     )
 
     if damping_rates is None:
-        damping_rate_x, damping_rate_y, damping_rate_z = (
-            twiss.damping_constants_s
-        )
+        damping_rate_x, damping_rate_y, damping_rate_z = twiss.damping_constants_s
     else:
-        damping_rate_x, damping_rate_y, damping_rate_z = (
-            damping_rates
-        )
+        damping_rate_x, damping_rate_y, damping_rate_z = damping_rates
 
     sigma_zeta = (input_emittance_z * longitudinal_emittance_ratio) ** 0.5
     sigma_delta = (input_emittance_z / longitudinal_emittance_ratio) ** 0.5
 
-    assert input_emittance_x > 0., ("'input_emittance_x' should be larger than"
-    " zero, try providing 'initial_emittances'")
-    assert input_emittance_y > 0., ("'input_emittance_y' should be larger than"
-    " zero, try providing 'initial_emittances'")
+    assert input_emittance_x > 0.0, (
+        "'input_emittance_x' should be larger than" " zero, try providing 'initial_emittances'"
+    )
+    assert input_emittance_y > 0.0, (
+        "'input_emittance_y' should be larger than" " zero, try providing 'initial_emittances'"
+    )
     ibs_growth_rates = twiss.get_ibs_growth_rates(
         formalism=formalism,
         total_beam_intensity=bunch_intensity,
@@ -99,7 +140,7 @@ def ibs_rates(
         sigma_delta=sigma_delta,
         bunch_length=sigma_zeta,  # 1 sigma_{zeta,RMS} bunch length
         bunched=True,
-    )                  
+    )
 
     depsilon_x_dt = (
         -2 * damping_rate_x * (input_emittance_x - natural_emittance_x)
@@ -112,12 +153,13 @@ def ibs_rates(
     depsilon_z_dt = (
         -2 * damping_rate_z * (input_emittance_z - natural_emittance_z)
         + ibs_growth_rates.Tz * input_emittance_z
-    )        
-    
+    )
+
     return (
         (depsilon_x_dt, depsilon_y_dt, depsilon_z_dt),
         (ibs_growth_rates.Tx, ibs_growth_rates.Ty, ibs_growth_rates.Tz),
     )
+
 
 def compute_emittance_evolution(
     twiss: xt.TwissTable,
@@ -148,19 +190,19 @@ def compute_emittance_evolution(
     bunch_intensity : float
         Bunch intensity [particles per bunch].
     initial_emittances : tuple of floats, optional
-        Initial values for the horizontal, vertical, and longitudinal 
-        emittances. If None, the equilibrium emittances from the Twiss object 
+        Initial values for the horizontal, vertical, and longitudinal
+        emittances. If None, the equilibrium emittances from the Twiss object
         are used. Default is None.
     emittance_coupling_factor : float, optional
-        Emittance coupling factor, defined as the ratio of vertical to 
+        Emittance coupling factor, defined as the ratio of vertical to
         horizontal emittance. Default is 0.
     emittance_constraint : str, optional
         Can enforces constraints on the transverse emittance based on the
-        emittance coupling factor. 
+        emittance coupling factor.
         "Coupling" corresponds to the case where the
         vertical emittance is the result of linear coupling.
-        "Excitation" corresponds to the case where the vertical emittance is 
-        the result of an excitation (e.g. from a feedback system). 
+        "Excitation" corresponds to the case where the vertical emittance is
+        the result of an excitation (e.g. from a feedback system).
         Default is "Coupling".
     input_sigma_zeta : float
         Used specified RMS momentum spread overwriting the natural one from
@@ -172,7 +214,7 @@ def compute_emittance_evolution(
         Natural emittances (horizontal, vertical, longitudinal).
         If None, they are taken from the `twiss` object. Default is None.
     rtol : float, optional
-        Relative tolerance for equilibrium emittance convergence. 
+        Relative tolerance for equilibrium emittance convergence.
         Default is 1e-6.
 
     Returns
@@ -195,53 +237,60 @@ def compute_emittance_evolution(
     if initial_emittances is None:
         print("Emittances from the Twiss object are being used.")
         emittance_x, emittance_y, emittance_z = (
-            twiss.eq_gemitt_x, twiss.eq_gemitt_y, twiss.eq_gemitt_zeta
+            twiss.eq_gemitt_x,
+            twiss.eq_gemitt_y,
+            twiss.eq_gemitt_zeta,
         )
-        # If emittance_coupling_factor is non zero, then natural emittance is 
+        # If emittance_coupling_factor is non zero, then natural emittance is
         # modified accordingly
-        if (
-            emittance_coupling_factor != 0
-            and emittance_constraint.lower() == "coupling"
-        ):
+        if emittance_coupling_factor != 0 and emittance_constraint.lower() == "coupling":
             # The convention used is valid for arbitrary damping partition
             # numbers and emittance_coupling_factor.
             emittance_y = (
-                emittance_x * emittance_coupling_factor
-                / (1 + emittance_coupling_factor *
-                twiss.partition_numbers[1] / twiss.partition_numbers[0])
+                emittance_x
+                * emittance_coupling_factor
+                / (
+                    1
+                    + emittance_coupling_factor
+                    * twiss.partition_numbers[1]
+                    / twiss.partition_numbers[0]
+                )
             )
-            emittance_x *= (
-                1 / (1 + emittance_coupling_factor *
-                twiss.partition_numbers[1] / twiss.partition_numbers[0])
+            emittance_x *= 1 / (
+                1
+                + emittance_coupling_factor
+                * twiss.partition_numbers[1]
+                / twiss.partition_numbers[0]
             )
-            
-        if (
-            emittance_coupling_factor != 0
-            and emittance_constraint.lower() == "excitation"
-        ):
+
+        if emittance_coupling_factor != 0 and emittance_constraint.lower() == "excitation":
             # The convention used only enforce a constraint on the vertical
             # emittance
             emittance_y = emittance_x * emittance_coupling_factor
     else:
         emittance_x, emittance_y, emittance_z = initial_emittances
-        
+
     sigma_zeta = (emittance_z * twiss.bets0) ** 0.5
     sigma_delta = (emittance_z / twiss.bets0) ** 0.5
     if input_sigma_zeta is not None:
-        warnings.warn("'input_sigma_zeta' is specified, make sure it remains "
-              "consistent with 'initial_emittances'.")
+        warnings.warn(
+            "'input_sigma_zeta' is specified, make sure it remains "
+            "consistent with 'initial_emittances'."
+        )
         sigma_zeta = input_sigma_zeta
     elif input_sigma_delta is not None:
-        warnings.warn("'input_sigma_delta' is specified, make sure it remains "
-              "consistent with 'initial_emittances'.")
-        sigma_delta = input_sigma_delta        
+        warnings.warn(
+            "'input_sigma_delta' is specified, make sure it remains "
+            "consistent with 'initial_emittances'."
+        )
+        sigma_delta = input_sigma_delta
     longitudinal_emittance_ratio = sigma_zeta / sigma_delta
-    if (input_sigma_zeta is not None or input_sigma_delta is not None):
+    if input_sigma_zeta is not None or input_sigma_delta is not None:
         assert initial_emittances is not None, (
             "Input of 'input_sigma_zeta' or 'input_sigma_delta' provided, but "
             "not of 'initial_emittances'. Please provide 'initial_emittances'."
         )
-    
+
     time = []
     emittances_x_list, emittances_y_list, emittances_z_list = [], [], []
     T_x, T_y, T_z = [], [], []
@@ -250,7 +299,7 @@ def compute_emittance_evolution(
     tol = np.inf
 
     current_emittances = np.array([emittance_x, emittance_y, emittance_z])
-    it = 0 # Iteration counter
+    it = 0  # Iteration counter
 
     while tol > rtol:
         # Print convergence progress
@@ -258,7 +307,9 @@ def compute_emittance_evolution(
 
         # Compute IBS emittance rates and growth rates
         ibs_emittance_rates, ibs_growth_rates = ibs_rates(
-            twiss, bunch_intensity, current_emittances,
+            twiss,
+            bunch_intensity,
+            current_emittances,
             initial_emittances=initial_emittances,
             emittance_coupling_factor=emittance_coupling_factor,
             emittance_constraint=emittance_constraint,
@@ -270,14 +321,13 @@ def compute_emittance_evolution(
 
         # Enforce constraints if specified
         if emittance_constraint.lower() == "coupling":
-            forced_emittance_x = (
-                (current_emittances[0] + current_emittances[1]) 
-                / (1 + emittance_coupling_factor)
+            forced_emittance_x = (current_emittances[0] + current_emittances[1]) / (
+                1 + emittance_coupling_factor
             )
             forced_emittance_y = forced_emittance_x * emittance_coupling_factor
             current_emittances[0] = forced_emittance_x
             current_emittances[1] = forced_emittance_y
-            
+
         if emittance_constraint.lower() == "excitation":
             forced_emittance_y = current_emittances[0] * emittance_coupling_factor
             current_emittances[1] = forced_emittance_y
@@ -293,17 +343,12 @@ def compute_emittance_evolution(
 
         # Compute tolerance
         if it > 0:
-            tol = np.max(
-                np.abs((current_emittances - previous_emittances) 
-                       / previous_emittances)
-            )
+            tol = np.max(np.abs((current_emittances - previous_emittances) / previous_emittances))
         # Store current emittances for the next iteration
         previous_emittances = current_emittances.copy()
 
         # Update time step for the next iteration
-        time_step = 0.01 / np.max(
-            (ibs_growth_rates, twiss.damping_constants_s)
-        )
+        time_step = 0.01 / np.max((ibs_growth_rates, twiss.damping_constants_s))
 
         it += 1
 

--- a/xfields/ibs/_equilibrium_emittance.py
+++ b/xfields/ibs/_equilibrium_emittance.py
@@ -63,7 +63,6 @@ def _ibs_rates_and_emittance_derivatives(
     input_emittances: tuple[float, float, float],
     formalism: Literal["Nagaitsev", "Bjorken-Mtingwa", "B&M"] = "Nagaitsev",
     longitudinal_emittance_ratio: float = None,
-    damping_rates: tuple = None,
     **kwargs,
 ) -> tuple[IBSGrowthRates, _EmittanceTimeDerivatives]:
     """
@@ -87,9 +86,6 @@ def _ibs_rates_and_emittance_derivatives(
         Ratio of the RMS bunch length to the RMS momentum spread. If provided,
         allows accounting for a perturbed longitudinal distrubtion due to
         bunch lengthening or a microwave instability. Default is None.
-    damping_rates : tuple[float, float, float], optional
-        SR damping rates (horizontal, vertical, longitudinal).
-        If None, they are taken from the `twiss` object. Default is None.
 
     Returns
     -------
@@ -102,13 +98,6 @@ def _ibs_rates_and_emittance_derivatives(
     input_emittance_x, input_emittance_y, input_emittance_z = input_emittances
 
     # TODO: can check that the SR eq emittances are present in twiss object (or in public func?)
-
-
-    # TODO: just take the damping constants from twiss and be done (remove param and docstring)
-    if damping_rates is None:
-        damping_rate_x, damping_rate_y, damping_rate_z = twiss.damping_constants_s
-    else:
-        damping_rate_x, damping_rate_y, damping_rate_z = damping_rates
 
     sigma_zeta = (input_emittance_z * longitudinal_emittance_ratio) ** 0.5
     sigma_delta = (input_emittance_z / longitudinal_emittance_ratio) ** 0.5
@@ -130,15 +119,15 @@ def _ibs_rates_and_emittance_derivatives(
     )
 
     depsilon_x_dt = (
-        -2 * damping_rate_x * (input_emittance_x - twiss.eq_gemitt_x)
+        -2 * twiss.damping_constants_s[0] * (input_emittance_x - twiss.eq_gemitt_x)
         + ibs_growth_rates.Tx * input_emittance_x
     )
     depsilon_y_dt = (
-        -2 * damping_rate_y * (input_emittance_y - twiss.eq_gemitt_y)
+        -2 * twiss.damping_constants_s[1] * (input_emittance_y - twiss.eq_gemitt_y)
         + ibs_growth_rates.Ty * input_emittance_y
     )
     depsilon_z_dt = (
-        -2 * damping_rate_z * (input_emittance_z - twiss.eq_gemitt_zeta)
+        -2 * twiss.damping_constants_s[2] * (input_emittance_z - twiss.eq_gemitt_zeta)
         + ibs_growth_rates.Tz * input_emittance_z
     )
 

--- a/xfields/ibs/_equilibrium_emittance.py
+++ b/xfields/ibs/_equilibrium_emittance.py
@@ -157,8 +157,8 @@ def _ibs_rates_and_emittance_derivatives(
     )
 
     return (
-        (depsilon_x_dt, depsilon_y_dt, depsilon_z_dt),
-        (ibs_growth_rates.Tx, ibs_growth_rates.Ty, ibs_growth_rates.Tz),
+        ibs_growth_rates,
+        _EmittanceTimeDerivatives(depsilon_x_dt, depsilon_y_dt, depsilon_z_dt),
     )
 
 
@@ -307,7 +307,7 @@ def compute_emittance_evolution(
         sys.stdout.write("\rConvergence = {:.1f}%".format(100 * rtol / tol))
 
         # Compute IBS emittance rates and growth rates
-        ibs_emittance_rates, ibs_growth_rates = _ibs_rates_and_emittance_derivatives(
+        ibs_growth_rates, ibs_emittance_rates = _ibs_rates_and_emittance_derivatives(
             twiss,
             bunch_intensity,
             current_emittances,

--- a/xfields/ibs/_equilibrium_emittance.py
+++ b/xfields/ibs/_equilibrium_emittance.py
@@ -84,9 +84,8 @@ def _ibs_rates_and_emittance_derivatives(
         Can be ``Nagaitsev`` or ``Bjorken-Mtingwa`` (also accepts ``B&M``),
         case-insensitively.
     longitudinal_emittance_ratio : float, optional
-        Ratio of the RMS bunch length to the RMS momentum spread. Used if
-        a user specified input_sigma_zeta or input_sigma_delta are given.
-        It allows accounting for a perturbed longitudinal distrubtion due to
+        Ratio of the RMS bunch length to the RMS momentum spread. If provided,
+        allows accounting for a perturbed longitudinal distrubtion due to
         bunch lengthening or a microwave instability. Default is None.
     damping_rates : tuple[float, float, float], optional
         SR damping rates (horizontal, vertical, longitudinal).

--- a/xfields/ibs/_equilibrium_emittance.py
+++ b/xfields/ibs/_equilibrium_emittance.py
@@ -60,45 +60,35 @@ class _EmittanceTimeDerivatives(xo.HybridClass):
 def _ibs_rates_and_emittance_derivatives(
     twiss: xt.TwissTable,
     bunch_intensity: float,
-    input_emittances: tuple,
+    input_emittances: tuple[float, float, float],
     formalism: Literal["Nagaitsev", "Bjorken-Mtingwa", "B&M"] = "Nagaitsev",
     longitudinal_emittance_ratio: float = None,
     damping_rates: tuple = None,
     **kwargs,
 ) -> tuple[IBSGrowthRates, _EmittanceTimeDerivatives]:
     """
-    Compute the IBS growth rates and emittance evolution rates.
+    Compute the IBS growth rates and emittance time derivatives from
+    the effect of both IBS and SR.
 
     Parameters
     ----------
-    twiss : object
-        Twiss object of the ring.
+    twiss : xtrack.TwissTable
+        Twiss results of the `xtrack.Line` configuration.
     bunch_intensity : float
         Bunch intensity [particles per bunch].
-    input_emittances : tuple of floats
-        Tuple containing the equilibrium transverse emittances (horizontal and
-        vertical).
-    emittance_coupling_factor : float, optional
-        Emittance coupling factor, defined as the ratio of vertical to
-        horizontal emittance.
-        Default is 0.
-    emittance_constraint : str, optional
-        Can enforces constraints on the transverse emittance based on the
-        emittance coupling factor.
-        "Coupling" corresponds to the case where the
-        vertical emittance is the result of linear coupling.
-        "Excitation" corresponds to the case where the vertical emittance is
-        the result of an excitation (e.g. from a feedback system).
-        Default is "Coupling".
-    formalism : str, optional
-        Which formalism to use for the computation. Can be ``Nagaitsev``
-        or ``Bjorken-Mtingwa`` (also accepts ``B&M``), case-insensitively.
+    input_emittances : tuple[float, float, float]
+        The bunch's starting geometric emittances in the horizontal,
+        vertical and longitudinal planes, in [m].
+    formalism : str
+        Which formalism to use for the computation of the IBS growth rates.
+        Can be ``Nagaitsev`` or ``Bjorken-Mtingwa`` (also accepts ``B&M``),
+        case-insensitively.
     longitudinal_emittance_ratio : float, optional
         Ratio of the RMS bunch length to the RMS momentum spread. Used if
-        an user specified input_sigma_zeta or input_sigma_delta are given.
+        a user specified input_sigma_zeta or input_sigma_delta are given.
         It allows accounting for a perturbed longitudinal distrubtion due to
         bunch lengthening or a microwave instability. Default is None.
-    damping_rates : tuple of floats, optional
+    damping_rates : tuple[float, float, float], optional
         SR damping rates (horizontal, vertical, longitudinal).
         If None, they are taken from the `twiss` object. Default is None.
 
@@ -109,14 +99,17 @@ def _ibs_rates_and_emittance_derivatives(
     ibs_growth_rates : tuple of floats
         IBS growth rates (horizontal, vertical, longitudinal).
     """
+    # TODO: bunch emittances - ask for the three separately and update docstring
     input_emittance_x, input_emittance_y, input_emittance_z = input_emittances
 
+    # TODO: just take from twiss parameter in calculations and remove this attribution
     natural_emittance_x, natural_emittance_y, natural_emittance_z = (
         twiss.eq_gemitt_x,
         twiss.eq_gemitt_y,
         twiss.eq_gemitt_zeta,
     )
 
+    # TODO: just take the damping constants from twiss and be done (remove param and docstring)
     if damping_rates is None:
         damping_rate_x, damping_rate_y, damping_rate_z = twiss.damping_constants_s
     else:

--- a/xfields/ibs/_equilibrium_emittance.py
+++ b/xfields/ibs/_equilibrium_emittance.py
@@ -101,12 +101,8 @@ def _ibs_rates_and_emittance_derivatives(
     # TODO: bunch emittances - ask for the three separately and update docstring
     input_emittance_x, input_emittance_y, input_emittance_z = input_emittances
 
-    # TODO: just take from twiss parameter in calculations and remove this attribution
-    natural_emittance_x, natural_emittance_y, natural_emittance_z = (
-        twiss.eq_gemitt_x,
-        twiss.eq_gemitt_y,
-        twiss.eq_gemitt_zeta,
-    )
+    # TODO: can check that the SR eq emittances are present in twiss object (or in public func?)
+
 
     # TODO: just take the damping constants from twiss and be done (remove param and docstring)
     if damping_rates is None:

--- a/xfields/ibs/_equilibrium_emittance.py
+++ b/xfields/ibs/_equilibrium_emittance.py
@@ -307,7 +307,7 @@ def compute_emittance_evolution(
         sys.stdout.write("\rConvergence = {:.1f}%".format(100 * rtol / tol))
 
         # Compute IBS growth rates and emittance derivatives
-        ibs_growth_rates, ibs_emittance_rates = _ibs_rates_and_emittance_derivatives(
+        ibs_growth_rates, emittance_derivatives = _ibs_rates_and_emittance_derivatives(
             twiss,
             bunch_intensity,
             current_emittances,
@@ -318,10 +318,10 @@ def compute_emittance_evolution(
         )
         # Make sure we have them as tuples for below
         ibs_growth_rates = ibs_growth_rates.as_tuple()
-        ibs_emittance_rates = ibs_emittance_rates.as_tuple()
+        emittance_derivatives = emittance_derivatives.as_tuple()
 
         # Update emittances
-        current_emittances += np.array(ibs_emittance_rates) * time_step
+        current_emittances += np.array(emittance_derivatives) * time_step
 
         # Enforce constraints if specified
         if emittance_constraint.lower() == "coupling":

--- a/xfields/ibs/_equilibrium_emittance.py
+++ b/xfields/ibs/_equilibrium_emittance.py
@@ -97,6 +97,12 @@ def _ibs_rates_and_emittance_derivatives(
     """
     # TODO: bunch emittances - ask for the three separately and update docstring
     input_emittance_x, input_emittance_y, input_emittance_z = input_emittances
+    assert input_emittance_x > 0.0, (
+        "'input_emittance_x' should be larger than" " zero, try providing 'initial_emittances'"
+    )
+    assert input_emittance_y > 0.0, (
+        "'input_emittance_y' should be larger than" " zero, try providing 'initial_emittances'"
+    )
 
     # TODO: can check that the SR eq emittances are present in twiss object (or in public func?) Could be:
     # if None in (
@@ -113,12 +119,7 @@ def _ibs_rates_and_emittance_derivatives(
     sigma_zeta = (input_emittance_z * longitudinal_emittance_ratio) ** 0.5
     sigma_delta = (input_emittance_z / longitudinal_emittance_ratio) ** 0.5
 
-    assert input_emittance_x > 0.0, (
-        "'input_emittance_x' should be larger than" " zero, try providing 'initial_emittances'"
-    )
-    assert input_emittance_y > 0.0, (
-        "'input_emittance_y' should be larger than" " zero, try providing 'initial_emittances'"
-    )
+
     ibs_growth_rates = twiss.get_ibs_growth_rates(
         formalism=formalism,
         total_beam_intensity=bunch_intensity,

--- a/xfields/ibs/_equilibrium_emittance.py
+++ b/xfields/ibs/_equilibrium_emittance.py
@@ -19,6 +19,7 @@ from xfields.ibs._analytical import IBSGrowthRates
 
 LOGGER = logging.getLogger(__name__)
 
+
 # ----- Some classes to store results (as xo.HybridClass) ----- #
 
 
@@ -56,7 +57,7 @@ class _EmittanceTimeDerivatives(xo.HybridClass):
         return float(self.dex), float(self.dey), float(self.dez)
 
 
-def ibs_rates(
+def _ibs_rates_and_emittance_derivatives(
     twiss: xt.TwissTable,
     bunch_intensity: float,
     input_emittances: tuple,
@@ -164,7 +165,7 @@ def ibs_rates(
 def compute_emittance_evolution(
     twiss: xt.TwissTable,
     bunch_intensity: float,
-    initial_emittances: Tuple = None,
+    initial_emittances: tuple = None,
     emittance_coupling_factor: float = 0,
     emittance_constraint: Literal["Coupling", "Excitation"] = "Coupling",
     input_sigma_zeta: float = None,
@@ -306,7 +307,7 @@ def compute_emittance_evolution(
         sys.stdout.write("\rConvergence = {:.1f}%".format(100 * rtol / tol))
 
         # Compute IBS emittance rates and growth rates
-        ibs_emittance_rates, ibs_growth_rates = ibs_rates(
+        ibs_emittance_rates, ibs_growth_rates = _ibs_rates_and_emittance_derivatives(
             twiss,
             bunch_intensity,
             current_emittances,

--- a/xfields/ibs/_equilibrium_emittance.py
+++ b/xfields/ibs/_equilibrium_emittance.py
@@ -156,7 +156,7 @@ def _ibs_rates_and_emittance_derivatives(
 
     return (
         ibs_growth_rates,
-        _EmittanceTimeDerivatives(depsilon_x_dt, depsilon_y_dt, depsilon_z_dt),
+        _EmittanceTimeDerivatives(dex=depsilon_x_dt, dey=depsilon_y_dt, dez=depsilon_z_dt),
     )
 
 

--- a/xfields/ibs/_equilibrium_emittance.py
+++ b/xfields/ibs/_equilibrium_emittance.py
@@ -61,8 +61,6 @@ def _ibs_rates_and_emittance_derivatives(
     twiss: xt.TwissTable,
     bunch_intensity: float,
     input_emittances: tuple,
-    emittance_coupling_factor: float = 0,
-    emittance_constraint: Literal["Coupling", "Excitation"] = "Coupling",
     formalism: Literal["Nagaitsev", "Bjorken-Mtingwa", "B&M"] = "Nagaitsev",
     longitudinal_emittance_ratio: float = None,
     damping_rates: tuple = None,

--- a/xfields/ibs/_equilibrium_emittance.py
+++ b/xfields/ibs/_equilibrium_emittance.py
@@ -366,3 +366,15 @@ def compute_emittance_evolution(
         T_y,
         T_z,
     )
+    # return Table(
+    #     data={
+    #         "time": np.cumsum(time),
+    #         "gemitt_x": emittances_x_list,
+    #         "gemitt_y": emittances_y_list,
+    #         "gemitt_z": emittances_z_list,
+    #         "Tx": Tx,
+    #         "Ty": Ty,
+    #         "Tz": Tz,
+    #     },
+    #     index="time",
+    # )

--- a/xfields/ibs/_equilibrium_emittance.py
+++ b/xfields/ibs/_equilibrium_emittance.py
@@ -23,7 +23,7 @@ LOGGER = logging.getLogger(__name__)
 # ----- Some classes to store results (as xo.HybridClass) ----- #
 
 
-class _EmittanceTimeDerivatives(xo.HybridClass):
+class EmittanceTimeDerivatives(xo.HybridClass):
     """
     Holds emittance evolution rates named ``dex``,
     ``dey``, and ``dez``. The values are expressed
@@ -64,7 +64,7 @@ def _ibs_rates_and_emittance_derivatives(
     formalism: Literal["Nagaitsev", "Bjorken-Mtingwa", "B&M"] = "Nagaitsev",
     longitudinal_emittance_ratio: float = None,
     **kwargs,
-) -> tuple[IBSGrowthRates, _EmittanceTimeDerivatives]:
+) -> tuple[IBSGrowthRates, EmittanceTimeDerivatives]:
     """
     Compute the IBS growth rates and emittance time derivatives from
     the effect of both IBS and SR.
@@ -89,10 +89,11 @@ def _ibs_rates_and_emittance_derivatives(
 
     Returns
     -------
-    emittance_rates : tuple of floats
-        Time variations of the emittances (horizontal, vertical, longitudinal).
-    ibs_growth_rates : tuple of floats
-        IBS growth rates (horizontal, vertical, longitudinal).
+    tuple[IBSGrowthRates, EmittanceTimeDerivatives]
+        Both the computed IBS growth rates and the emittance time derivatives
+        from the contributions of SR and IBS, each in a specific container
+        object (namely ``IBSGrowthRates`` and ``EmittanceTimeDerivatives``,
+        respectively).
     """
     # TODO: bunch emittances - ask for the three separately and update docstring
     input_emittance_x, input_emittance_y, input_emittance_z = input_emittances
@@ -133,7 +134,7 @@ def _ibs_rates_and_emittance_derivatives(
 
     return (
         ibs_growth_rates,
-        _EmittanceTimeDerivatives(dex=depsilon_x_dt, dey=depsilon_y_dt, dez=depsilon_z_dt),
+        EmittanceTimeDerivatives(dex=depsilon_x_dt, dey=depsilon_y_dt, dez=depsilon_z_dt),
     )
 
 

--- a/xfields/ibs/_equilibrium_emittance.py
+++ b/xfields/ibs/_equilibrium_emittance.py
@@ -306,7 +306,7 @@ def compute_emittance_evolution(
         # Print convergence progress
         sys.stdout.write("\rConvergence = {:.1f}%".format(100 * rtol / tol))
 
-        # Compute IBS emittance rates and growth rates
+        # Compute IBS growth rates and emittance derivatives
         ibs_growth_rates, ibs_emittance_rates = _ibs_rates_and_emittance_derivatives(
             twiss,
             bunch_intensity,
@@ -316,6 +316,9 @@ def compute_emittance_evolution(
             emittance_constraint=emittance_constraint,
             longitudinal_emittance_ratio=longitudinal_emittance_ratio,
         )
+        # Make sure we have them as tuples for below
+        ibs_growth_rates = ibs_growth_rates.as_tuple()
+        ibs_emittance_rates = ibs_emittance_rates.as_tuple()
 
         # Update emittances
         current_emittances += np.array(ibs_emittance_rates) * time_step

--- a/xfields/ibs/_equilibrium_emittance.py
+++ b/xfields/ibs/_equilibrium_emittance.py
@@ -59,7 +59,7 @@ class EmittanceTimeDerivatives(xo.HybridClass):
 
 def _ibs_rates_and_emittance_derivatives(
     twiss: xt.TwissTable,
-    bunch_intensity: float,
+    bunch_intensity: float,  # TODO: rename total_beam_intensity like in rest of APIs, confirm Seb is ok
     input_emittances: tuple[float, float, float],
     formalism: Literal["Nagaitsev", "Bjorken-Mtingwa", "B&M"] = "Nagaitsev",
     longitudinal_emittance_ratio: float = None,


### PR DESCRIPTION
Most of the changes here are quite simple for now, and the main function is barely touched.

Notable:
- Some more imports
- Round of formatting (unwanted changes will be handled and flags added later for formulas)
- Xobjects structure for the emittance time derivatives (à la IBSGrowthRates)
- Inner function is now private and returns a tuple of the rates and the derivatives objects (this is correctly handled / modified in the caller)
- Removed unused parameters from inner private function (re: coupling/excitation handling)
- Updated docstring
- Used directly attributes from TwissTable with no unpacking
- Added comments and walkthrough (plus some TODOs)
- Prepared (commented out) for the main function to return a Table object

Will run a small script tomorrow morning with your branch state and then mine to make sure results are the same. Since the main function has not changed interface, it should run on both branches with no difficulties.