### PR TITLE
Second round of cosmetics

### DIFF
--- a/xfields/ibs/_equilibrium_emittance.py
+++ b/xfields/ibs/_equilibrium_emittance.py
@@ -346,7 +346,7 @@ def compute_emittance_evolution(
     # Start the iterative process until convergence:
     # - Compute IBS rates and emittance time derivatives
     # - Update emittances using the time derivatives and time step
-    # - Enforce transverse / longitudinal constraints if specified
+    # - Enforce transverse constraints if specified
     # - Store all intermediate results for this time step
     # - Compute tolerance and check for convergence
     while tolerance > rtol:

--- a/xfields/ibs/_equilibrium_emittance.py
+++ b/xfields/ibs/_equilibrium_emittance.py
@@ -104,10 +104,10 @@ def _ibs_rates_and_emittance_derivatives(
     # TODO: bunch emittances - ask for the three separately and update docstring
     input_emittance_x, input_emittance_y, input_emittance_z = input_emittances
     assert input_emittance_x > 0.0, (
-        "'input_emittance_x' should be larger than" " zero, try providing 'initial_emittances'"
+        "'input_emittance_x' should be larger than zero, try providing 'initial_emittances'"
     )
     assert input_emittance_y > 0.0, (
-        "'input_emittance_y' should be larger than" " zero, try providing 'initial_emittances'"
+        "'input_emittance_y' should be larger than zero, try providing 'initial_emittances'"
     )
     # ----------------------------------------------------------------------------------------------
     # TODO: check for SR eq emittances etc in twiss table (or in public func?) Could be:

--- a/xfields/ibs/_equilibrium_emittance.py
+++ b/xfields/ibs/_equilibrium_emittance.py
@@ -222,9 +222,8 @@ def compute_emittance_evolution(
         computed from the longitudinal emittance. Defaults to `None`.
 
 
-    natural_emittances : tuple of floats, optional
-        Natural emittances (horizontal, vertical, longitudinal).
-        If None, they are taken from the `twiss` object. Default is None.
+
+
     rtol : float, optional
         Relative tolerance for equilibrium emittance convergence.
         Default is 1e-6.

--- a/xfields/ibs/_equilibrium_emittance.py
+++ b/xfields/ibs/_equilibrium_emittance.py
@@ -220,13 +220,11 @@ def compute_emittance_evolution(
     sigma_delta : float, optional
         The RMS momentum spread of the bunch. If provided, overwrites the one
         computed from the longitudinal emittance. Defaults to `None`.
-
-
-
-
     rtol : float, optional
-        Relative tolerance for equilibrium emittance convergence.
-        Default is 1e-6.
+        Relative tolerance to determine when convergence is reached: if the relative
+        difference between the computed emittances and those at the previous step is
+        below `rtol`, then convergence is considered achieved. Defaults to 1e-6.
+
 
     Returns
     -------

--- a/xfields/ibs/_equilibrium_emittance.py
+++ b/xfields/ibs/_equilibrium_emittance.py
@@ -163,6 +163,7 @@ def _ibs_rates_and_emittance_derivatives(
     )
 
 
+# TODO: find a better, more explicit name for this
 def compute_emittance_evolution(
     twiss: xt.TwissTable,
     formalism: Literal["Nagaitsev", "Bjorken-Mtingwa", "B&M"],

--- a/xfields/ibs/_equilibrium_emittance.py
+++ b/xfields/ibs/_equilibrium_emittance.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 import logging
-import sys
 import warnings
 from typing import Literal
 
@@ -182,6 +181,7 @@ def compute_emittance_evolution(
     overwrite_sigma_zeta: float = None,
     overwrite_sigma_delta: float = None,
     rtol: float = 1e-6,
+    verbose: bool = True,
     **kwargs,
 ):
     # TODO: rework this main chunk of docstring
@@ -239,6 +239,9 @@ def compute_emittance_evolution(
         Relative tolerance to determine when convergence is reached: if the relative
         difference between the computed emittances and those at the previous step is
         below `rtol`, then convergence is considered achieved. Defaults to 1e-6.
+    verbose : bool, optional
+        Whether to print out information on the current iteration step and estimated
+        convergence progress. Defaults to `False`.
     **kwargs : dict
         Keyword arguments are passed to the growth rates computation method of
         the chosen IBS formalism implementation. See the formalism classes in
@@ -341,8 +344,8 @@ def compute_emittance_evolution(
     # - Store all intermediate results for this time step
     # - Compute tolerance and check for convergence
     while tolerance > rtol:
-        # Print convergence progress
-        sys.stdout.write(f"\rIteration {iterations} - convergence = {100 * rtol / tolerance:.1f}%")
+        if verbose is True:  # Display estimated convergence progress if asked
+            xo.general._print(f"Iteration {iterations} - convergence = {100 * rtol / tolerance:.1f}%", end="\r")
 
         # Compute IBS growth rates and emittance derivatives
         ibs_growth_rates, emittance_derivatives = _ibs_rates_and_emittance_derivatives(

--- a/xfields/ibs/_equilibrium_emittance.py
+++ b/xfields/ibs/_equilibrium_emittance.py
@@ -186,6 +186,15 @@ def compute_emittance_evolution(
 ):
     # TODO: rework this main chunk of docstring
     """
+    Compute the evolution of beam emittances due to IBS until convergence.
+    By default, the function assumes the emittances from the Twiss object.
+    They can also be specified as well as different natural emittances.
+    The emittance evolution can be constrained to follow two scenarios:
+        - A vertical emittance originating from linear coupling.
+        - A vertical emittance originating from an excitation.
+    The impact from the longitudinal impedance (e.g. bunch lengthening or
+    microwave instability) can be accounted for by specifying the RMS bunch
+    length and momentum spread.
 
     Parameters
     ----------

--- a/xfields/ibs/_equilibrium_emittance.py
+++ b/xfields/ibs/_equilibrium_emittance.py
@@ -245,7 +245,7 @@ def compute_emittance_evolution(
         below `rtol`, then convergence is considered achieved. Defaults to 1e-6.
     verbose : bool, optional
         Whether to print out information on the current iteration step and estimated
-        convergence progress. Defaults to `False`.
+        convergence progress. Defaults to `True`.
     **kwargs : dict
         Keyword arguments are passed to the growth rates computation method of
         the chosen IBS formalism implementation. See the formalism classes in

--- a/xfields/ibs/_equilibrium_emittance.py
+++ b/xfields/ibs/_equilibrium_emittance.py
@@ -167,7 +167,14 @@ def compute_emittance_evolution(
     twiss: xt.TwissTable,
     formalism: Literal["Nagaitsev", "Bjorken-Mtingwa", "B&M"],
     total_beam_intensity: int,
+    # TODO: want to force providing gemitt_x, gemitt_y & gemitt_zeta instead of this initial_emittances (can allow nemitt_x and add checks / conversions)
     initial_emittances: tuple[float, float, float] = None,
+    # gemitt_x: float = None,
+    # nemitt_x: float = None,
+    # gemitt_y: float = None,
+    # nemitt_y: float = None,
+    # gemitt_zeta: float = None,
+    # nemitt_zeta: float = None,
     emittance_coupling_factor: float = 0,
     emittance_constraint: Literal["Coupling", "Excitation"] = "Coupling",
     # TODO: move these two (still optional) below gemitt_x, gemitt_y, gemitt_zeta when modify that
@@ -243,6 +250,27 @@ def compute_emittance_evolution(
     T_z : list of float
         Longitudinal IBS growth rates computed over all the time steps.
     """
+    # Returns
+    # -------
+    # xtrack.TwissTable
+    #     The convergence calculations results. The table contains the following
+    #     columns, as time-step by time-step quantities:
+    #         - time: time values at which quantities are computed, in [s]
+    #         - gemitt_x: horizontal geometric emittance values, in [m]
+    #         - gemitt_y: vertical geometric emittance values, in [m]
+    #         - gemitt_zeta: longitudinal geometric emittance values, in [m]
+    #         - Tx: horizontal IBS growth rate, in [s^-1]
+    #         - Ty: vertical IBS growth rate, in [s^-1]
+    #         - Tz: longitudinal IBS growth rate, in [s^-1]
+    #     The table also contains the following global quantities:
+    #         - damping_constants_s: radiation damping constants per second used for the calculations
+    #         - partition_numbers: damping partition numbers used for the calculations
+    #         - eq_gemitt_x: final horizontal equilibrium geometric emittance converged to, in [m]
+    #         - eq_gemitt_y: final vertical equilibrium geometric emittance converged to, in [m]
+    #         - eq_gemitt_zeta: final longitudinal equilibrium geometric emittance converged to, in [m]
+    #         - sr_eq_gemitt_x: horizontal equilibrium geometric emittance from synchrotron radiation used, in [m]
+    #         - sr_eq_gemitt_y: vertical equilibrium geometric emittance from synchrotron radiation used, in [m]
+    #         - eq_nemitt_zeta: longitudinal equilibrium normalized emittance from synchrotron radiation used, in [m]
     # ----------------------------------------------------------------------------------------------
     # Handle initial transverse emittances and potential effect of coupling / excitation constraints
     # TODO: I don't like this, would rather force the user to provide gemitt_x, gemitt_y & gemitt_zeta
@@ -368,7 +396,7 @@ def compute_emittance_evolution(
     #         "time": np.cumsum(time),
     #         "gemitt_x": emittances_x_list,
     #         "gemitt_y": emittances_y_list,
-    #         "gemitt_z": emittances_z_list,
+    #         "gemitt_zeta": emittances_z_list,
     #         "Tx": Tx,
     #         "Ty": Ty,
     #         "Tz": Tz,
@@ -379,6 +407,7 @@ def compute_emittance_evolution(
     # result_table._data.update(
     #     {
     #         "damping_constants_s": twiss.damping_constants_s,
+    #         "partition_numbers": twiss.partition_numbers,
     #         "eq_gemitt_x": emittances_x_list[-1],
     #         "eq_gemitt_x": emittances_y_list[-1],
     #         "eq_gemitt_x": emittances_z_list[-1],

--- a/xfields/ibs/_equilibrium_emittance.py
+++ b/xfields/ibs/_equilibrium_emittance.py
@@ -323,6 +323,7 @@ def compute_emittance_evolution(
             total_beam_intensity=total_beam_intensity,
             input_emittances=current_emittances,
             longitudinal_emittance_ratio=longitudinal_emittance_ratio,
+            **kwargs,
         )
         # Make sure we have them as tuples for below
         ibs_growth_rates = ibs_growth_rates.as_tuple()

--- a/xfields/ibs/_equilibrium_emittance.py
+++ b/xfields/ibs/_equilibrium_emittance.py
@@ -176,6 +176,7 @@ def compute_emittance_evolution(
     rtol: float = 1e-6,
     **kwargs,
 ):
+    # TODO: rework this main chunk of docstring
     """
     Compute the evolution of beam emittances due to IBS until convergence.
     By default, the function assumes the emittances from the Twiss object.
@@ -224,7 +225,10 @@ def compute_emittance_evolution(
         Relative tolerance to determine when convergence is reached: if the relative
         difference between the computed emittances and those at the previous step is
         below `rtol`, then convergence is considered achieved. Defaults to 1e-6.
-
+    **kwargs : dict
+        Keyword arguments are passed to the growth rates computation method of
+        the chosen IBS formalism implementation. See the formalism classes in
+        the ``xfields.ibs._analytical`` for more details.
 
     Returns
     -------
@@ -314,12 +318,10 @@ def compute_emittance_evolution(
 
         # Compute IBS growth rates and emittance derivatives
         ibs_growth_rates, emittance_derivatives = _ibs_rates_and_emittance_derivatives(
-            twiss,
-            total_beam_intensity,
-            current_emittances,
-            initial_emittances=initial_emittances,
-            emittance_coupling_factor=emittance_coupling_factor,
-            emittance_constraint=emittance_constraint,
+            twiss=twiss,
+            formalism=formalism,
+            total_beam_intensity=total_beam_intensity,
+            input_emittances=current_emittances,
             longitudinal_emittance_ratio=longitudinal_emittance_ratio,
         )
         # Make sure we have them as tuples for below

--- a/xfields/ibs/_equilibrium_emittance.py
+++ b/xfields/ibs/_equilibrium_emittance.py
@@ -361,18 +361,9 @@ def compute_emittance_evolution(
 
         it += 1
     # ----------------------------------------------------------------------------------------------
-    # Return the results
+    # Return a table with the results and return it
     print("\nConverged!")
-    return (
-        np.cumsum(time),
-        emittances_x_list,
-        emittances_y_list,
-        emittances_z_list,
-        T_x,
-        T_y,
-        T_z,
-    )
-    # return Table(
+    # result_table = Table(
     #     data={
     #         "time": np.cumsum(time),
     #         "gemitt_x": emittances_x_list,
@@ -384,3 +375,25 @@ def compute_emittance_evolution(
     #     },
     #     index="time",
     # )
+    # Provide global quantities as well
+    # result_table._data.update(
+    #     {
+    #         "damping_constants_s": twiss.damping_constants_s,
+    #         "eq_gemitt_x": emittances_x_list[-1],
+    #         "eq_gemitt_x": emittances_y_list[-1],
+    #         "eq_gemitt_x": emittances_z_list[-1],
+    #         "sr_eq_gemitt_x": twiss.eq_gemitt_x,
+    #         "sr_eq_gemitt_y": twiss.eq_gemitt_y,
+    #         "eq_nemitt_zeta": twiss.eq_nemitt_zeta,
+    #     }
+    # )
+    # return result_table
+    return (
+        np.cumsum(time),
+        emittances_x_list,
+        emittances_y_list,
+        emittances_z_list,
+        T_x,
+        T_y,
+        T_z,
+    )

--- a/xfields/ibs/_equilibrium_emittance.py
+++ b/xfields/ibs/_equilibrium_emittance.py
@@ -78,7 +78,7 @@ def _ibs_rates_and_emittance_derivatives(
         Can be ``Nagaitsev`` or ``Bjorken-Mtingwa`` (also accepts ``B&M``),
         case-insensitively.
     total_beam_intensity : int
-        The beam or bunch intensity, in [particles per bunch].
+        The bunch intensity, in [particles per bunch].
     input_emittances : tuple[float, float, float]
         The bunch's starting geometric emittances in the horizontal,
         vertical and longitudinal planes, in [m].
@@ -178,15 +178,6 @@ def compute_emittance_evolution(
 ):
     # TODO: rework this main chunk of docstring
     """
-    Compute the evolution of beam emittances due to IBS until convergence.
-    By default, the function assumes the emittances from the Twiss object.
-    They can also be specified as well as different natural emittances.
-    The emittance evolution can be constrained to follow two scenarios:
-        - A vertical emittance originating from linear coupling.
-        - A vertical emittance originating from an excitation.
-    The impact from the longitudinal impedance (e.g. bunch lengthening or
-    microwave instability) can be accounted for by specifying the RMS bunch
-    length and momentum spread.
 
     Parameters
     ----------
@@ -197,7 +188,7 @@ def compute_emittance_evolution(
         Can be ``Nagaitsev`` or ``Bjorken-Mtingwa`` (also accepts ``B&M``),
         case-insensitively.
     total_beam_intensity : int
-        The beam or bunch intensity, in [particles per bunch].
+        The bunch intensity, in [particles per bunch].
     initial_emittances : tuple[float, float, float], optional
         The bunch's starting geometric emittances in the horizontal,
         vertical and longitudinal planes, in [m]. If not provided, the
@@ -205,16 +196,21 @@ def compute_emittance_evolution(
         to `None`.
     emittance_coupling_factor : float, optional
         The ratio of vertical to horizontal emittances. If a value is provided
-        and `emittance_constraint` is set to `coupling`, then this ratio is
-        preserved. Defaults to 0.
+        it is taken into account for the evolution of emittances. See the next
+        parameter for possible scenarios. Defaults to 0.
     emittance_constraint : str, optional
         If an accepted value is provided, enforces constraints on the transverse
         emittances. Can be either "coupling" or "excitation", case-insensitively.
-            If `coupling`, vertical emittance is the result of linear coupling and is
-            determined from the horizontal one based on the `emittance_coupling_factor`.
-            If `excitation`, vertical emittance is the result of an excitation (e.g. from
-            a feedback system).
-        Defaults to "coupling", with no effect as `emittance_coupling_factor` defaults to 0.
+        Defaults to "coupling".
+          - If `coupling`, vertical emittance is the result of linear coupling. In
+            this case both the vertical and horizontal emittances are altered and
+            determined based on the value of `emittance_coupling_factor` such that
+            the total transverse IS preserved.
+          - If `excitation`, vertical emittance is the result of an excitation
+            (e.g. from a feedback system) and is determined from the horizontal
+            emittance based on the value of `emittance_coupling_factor`. In this
+            case the total transverse emittance is NOT preserved.
+        This has no effect by default as `emittance_coupling_factor` defaults to 0.
     sigma_zeta : float, optional
         The RMS bunch length. If provided, overwrites the one computed from
         the longitudinal emittance. Defaults to `None`.

--- a/xfields/ibs/_equilibrium_emittance.py
+++ b/xfields/ibs/_equilibrium_emittance.py
@@ -170,8 +170,9 @@ def compute_emittance_evolution(
     initial_emittances: tuple[float, float, float] = None,
     emittance_coupling_factor: float = 0,
     emittance_constraint: Literal["Coupling", "Excitation"] = "Coupling",
-    input_sigma_zeta: float = None,
-    input_sigma_delta: float = None,
+    # TODO: move these two (still optional) below gemitt_x, gemitt_y, gemitt_zeta when modify that
+    sigma_zeta: float = None,
+    sigma_delta: float = None,
     rtol: float = 1e-6,
     **kwargs,
 ):
@@ -213,15 +214,14 @@ def compute_emittance_evolution(
             If `excitation`, vertical emittance is the result of an excitation (e.g. from
             a feedback system).
         Defaults to "coupling", with no effect as `emittance_coupling_factor` defaults to 0.
+    sigma_zeta : float, optional
+        The RMS bunch length. If provided, overwrites the one computed from
+        the longitudinal emittance. Defaults to `None`.
+    sigma_delta : float, optional
+        The RMS momentum spread of the bunch. If provided, overwrites the one
+        computed from the longitudinal emittance. Defaults to `None`.
 
 
-        
-    input_sigma_zeta : float
-        Used specified RMS momentum spread overwriting the natural one from
-        the `twiss` object. Default is None.
-    input_sigma_delta : float
-        Used specified RMS momentum spread overwriting the natural one from
-        the `twiss` object. Default is None.
     natural_emittances : tuple of floats, optional
         Natural emittances (horizontal, vertical, longitudinal).
         If None, they are taken from the `twiss` object. Default is None.
@@ -275,20 +275,20 @@ def compute_emittance_evolution(
     # Handle initial longitudinal emittance and potential effect of bunch lengthening
     sigma_zeta = (emittance_z * twiss.bets0) ** 0.5
     sigma_delta = (emittance_z / twiss.bets0) ** 0.5
-    if input_sigma_zeta is not None:
+    if sigma_zeta is not None:
         warnings.warn(
             "'input_sigma_zeta' is specified, make sure it remains "
             "consistent with 'initial_emittances'."
         )
-        sigma_zeta = input_sigma_zeta
-    elif input_sigma_delta is not None:
+        sigma_zeta = sigma_zeta
+    elif sigma_delta is not None:
         warnings.warn(
             "'input_sigma_delta' is specified, make sure it remains "
             "consistent with 'initial_emittances'."
         )
-        sigma_delta = input_sigma_delta
+        sigma_delta = sigma_delta
     longitudinal_emittance_ratio = sigma_zeta / sigma_delta
-    if input_sigma_zeta is not None or input_sigma_delta is not None:
+    if sigma_zeta is not None or sigma_delta is not None:
         assert initial_emittances is not None, (
             "Input of 'input_sigma_zeta' or 'input_sigma_delta' provided, but "
             "not of 'initial_emittances'. Please provide 'initial_emittances'."

--- a/xfields/ibs/_equilibrium_emittance.py
+++ b/xfields/ibs/_equilibrium_emittance.py
@@ -167,7 +167,7 @@ def compute_emittance_evolution(
     twiss: xt.TwissTable,
     formalism: Literal["Nagaitsev", "Bjorken-Mtingwa", "B&M"],
     total_beam_intensity: int,
-    initial_emittances: tuple = None,
+    initial_emittances: tuple[float, float, float] = None,
     emittance_coupling_factor: float = 0,
     emittance_constraint: Literal["Coupling", "Excitation"] = "Coupling",
     input_sigma_zeta: float = None,
@@ -196,21 +196,26 @@ def compute_emittance_evolution(
         case-insensitively.
     total_beam_intensity : int
         The beam or bunch intensity, in [particles per bunch].
-    initial_emittances : tuple of floats, optional
-        Initial values for the horizontal, vertical, and longitudinal
-        emittances. If None, the equilibrium emittances from the Twiss object
-        are used. Default is None.
+    initial_emittances : tuple[float, float, float], optional
+        The bunch's starting geometric emittances in the horizontal,
+        vertical and longitudinal planes, in [m]. If not provided, the
+        SR equilibrium emittances from the TwissTable are used. Defaults
+        to `None`.
     emittance_coupling_factor : float, optional
-        Emittance coupling factor, defined as the ratio of vertical to
-        horizontal emittance. Default is 0.
+        The ratio of vertical to horizontal emittances. If a value is provided
+        and `emittance_constraint` is set to `coupling`, then this ratio is
+        preserved. Defaults to 0.
     emittance_constraint : str, optional
-        Can enforces constraints on the transverse emittance based on the
-        emittance coupling factor.
-        "Coupling" corresponds to the case where the
-        vertical emittance is the result of linear coupling.
-        "Excitation" corresponds to the case where the vertical emittance is
-        the result of an excitation (e.g. from a feedback system).
-        Default is "Coupling".
+        If an accepted value is provided, enforces constraints on the transverse
+        emittances. Can be either "coupling" or "excitation", case-insensitively.
+            If `coupling`, vertical emittance is the result of linear coupling and is
+            determined from the horizontal one based on the `emittance_coupling_factor`.
+            If `excitation`, vertical emittance is the result of an excitation (e.g. from
+            a feedback system).
+        Defaults to "coupling", with no effect as `emittance_coupling_factor` defaults to 0.
+
+
+        
     input_sigma_zeta : float
         Used specified RMS momentum spread overwriting the natural one from
         the `twiss` object. Default is None.

--- a/xfields/ibs/_equilibrium_emittance.py
+++ b/xfields/ibs/_equilibrium_emittance.py
@@ -332,6 +332,7 @@ def compute_emittance_evolution(
             "Input of 'overwrite_sigma_zeta' or 'overwrite_sigma_delta' provided, but "
             "not of 'initial_emittances'. Please provide 'initial_emittances'."
         )
+    # TODO: potentially here we redefine the emittance_z here as the ratio after the change here (product of the two sigmas)
     # ----------------------------------------------------------------------------------------------
     # Start structures to store the iterative results until convergence
     tolerance = np.inf

--- a/xfields/ibs/_equilibrium_emittance.py
+++ b/xfields/ibs/_equilibrium_emittance.py
@@ -223,13 +223,16 @@ def compute_emittance_evolution(
         Defaults to "coupling".
           - If `coupling`, vertical emittance is the result of linear coupling. In
             this case both the vertical and horizontal emittances are altered and
-            determined based on the value of `emittance_coupling_factor` such that
-            the total transverse IS preserved.
+            determined based on the value of `emittance_coupling_factor` and the
+            damping partition numbers. If the horizontal and vertical partition
+            numbers are equal then the total transverse emittance is preserved.
           - If `excitation`, vertical emittance is the result of an excitation
             (e.g. from a feedback system) and is determined from the horizontal
             emittance based on the value of `emittance_coupling_factor`. In this
             case the total transverse emittance is NOT preserved.
-        This has no effect by default as `emittance_coupling_factor` defaults to 0.
+        Providing `None` or an empty string allows one to study a scenarion without
+        constraint. Note as `emittance_coupling_factor` defaults to 0, this parameter
+        has no effect unless a non-zero value is provided.
     overwrite_sigma_zeta : float, optional
         The RMS bunch length. If provided, overwrites the one computed from
         the longitudinal emittance. Defaults to `None`.

--- a/xfields/ibs/_equilibrium_emittance.py
+++ b/xfields/ibs/_equilibrium_emittance.py
@@ -86,6 +86,10 @@ def _ibs_rates_and_emittance_derivatives(
         Ratio of the RMS bunch length to the RMS momentum spread. If provided,
         allows accounting for a perturbed longitudinal distrubtion due to
         bunch lengthening or a microwave instability. Default is None.
+    **kwargs : dict
+        Keyword arguments are passed to the growth rates computation method of
+        the chosen IBS formalism implementation. See the formalism classes in
+        the ``xfields.ibs._analytical`` for more details.
 
     Returns
     -------
@@ -133,6 +137,7 @@ def _ibs_rates_and_emittance_derivatives(
         sigma_delta=sigma_delta,
         bunch_length=sigma_zeta,  # 1 sigma_{zeta,RMS} bunch length
         bunched=True,
+        **kwargs,
     )
     # ----------------------------------------------------------------------------------------------
     # Computing the emittance time derivatives analytically.

--- a/xfields/ibs/_equilibrium_emittance.py
+++ b/xfields/ibs/_equilibrium_emittance.py
@@ -177,10 +177,10 @@ def compute_emittance_evolution(
     # gemitt_zeta: float = None,
     # nemitt_zeta: float = None,
     emittance_coupling_factor: float = 0,
-    emittance_constraint: Literal["Coupling", "Excitation"] = "Coupling",
+    emittance_constraint: Literal["coupling", "excitation"] = "coupling",
     # TODO: move these two (still optional) below gemitt_x, gemitt_y, gemitt_zeta when modify that
-    sigma_zeta: float = None,
-    sigma_delta: float = None,
+    overwrite_sigma_zeta: float = None,
+    overwrite_sigma_delta: float = None,
     rtol: float = 1e-6,
     **kwargs,
 ):
@@ -228,10 +228,10 @@ def compute_emittance_evolution(
             emittance based on the value of `emittance_coupling_factor`. In this
             case the total transverse emittance is NOT preserved.
         This has no effect by default as `emittance_coupling_factor` defaults to 0.
-    sigma_zeta : float, optional
+    overwrite_sigma_zeta : float, optional
         The RMS bunch length. If provided, overwrites the one computed from
         the longitudinal emittance. Defaults to `None`.
-    sigma_delta : float, optional
+    overwrite_sigma_delta : float, optional
         The RMS momentum spread of the bunch. If provided, overwrites the one
         computed from the longitudinal emittance. Defaults to `None`.
     rtol : float, optional
@@ -310,22 +310,16 @@ def compute_emittance_evolution(
     # Handle initial longitudinal emittance and potential effect of bunch lengthening
     sigma_zeta = (emittance_z * twiss.bets0) ** 0.5
     sigma_delta = (emittance_z / twiss.bets0) ** 0.5
-    if sigma_zeta is not None:
-        warnings.warn(
-            "'sigma_zeta' is specified, make sure it remains "
-            "consistent with 'initial_emittances'."
-        )
-        sigma_zeta = sigma_zeta
-    elif sigma_delta is not None:
-        warnings.warn(
-            "'sigma_delta' is specified, make sure it remains "
-            "consistent with 'initial_emittances'."
-        )
-        sigma_delta = sigma_delta
+    if overwrite_sigma_zeta is not None:
+        warnings.warn("'overwrite_sigma_zeta' is specified, make sure it remains consistent with 'initial_emittances'.")
+        sigma_zeta = overwrite_sigma_zeta
+    elif overwrite_sigma_delta is not None:
+        warnings.warn("'sigma_delta' is specified, make sure it remains consistent with 'initial_emittances'.")
+        sigma_delta = overwrite_sigma_delta
     longitudinal_emittance_ratio = sigma_zeta / sigma_delta
-    if sigma_zeta is not None or sigma_delta is not None:
+    if overwrite_sigma_zeta is not None or overwrite_sigma_delta is not None:
         assert initial_emittances is not None, (
-            "Input of 'input_sigma_zeta' or 'input_sigma_delta' provided, but "
+            "Input of 'overwrite_sigma_zeta' or 'overwrite_sigma_delta' provided, but "
             "not of 'initial_emittances'. Please provide 'initial_emittances'."
         )
     # ----------------------------------------------------------------------------------------------

--- a/xfields/ibs/_equilibrium_emittance.py
+++ b/xfields/ibs/_equilibrium_emittance.py
@@ -379,7 +379,7 @@ def compute_emittance_evolution(
             current_emittances[0] = forced_emittance_x
             current_emittances[1] = forced_emittance_y
 
-        if emittance_constraint.lower() == "excitation":
+        elif emittance_constraint.lower() == "excitation":
             forced_emittance_y = current_emittances[0] * emittance_coupling_factor
             current_emittances[1] = forced_emittance_y
 

--- a/xfields/ibs/_equilibrium_emittance.py
+++ b/xfields/ibs/_equilibrium_emittance.py
@@ -136,7 +136,6 @@ def _ibs_rates_and_emittance_derivatives(
         gemitt_y=input_emittance_y,
         sigma_delta=sigma_delta,
         bunch_length=sigma_zeta,  # 1 sigma_{zeta,RMS} bunch length
-        bunched=True,
         **kwargs,
     )
     # ----------------------------------------------------------------------------------------------

--- a/xfields/ibs/_equilibrium_emittance.py
+++ b/xfields/ibs/_equilibrium_emittance.py
@@ -288,7 +288,7 @@ def compute_emittance_evolution(
     #         - eq_gemitt_zeta: final longitudinal equilibrium geometric emittance converged to, in [m]
     #         - sr_eq_gemitt_x: horizontal equilibrium geometric emittance from synchrotron radiation used, in [m]
     #         - sr_eq_gemitt_y: vertical equilibrium geometric emittance from synchrotron radiation used, in [m]
-    #         - eq_nemitt_zeta: longitudinal equilibrium normalized emittance from synchrotron radiation used, in [m]
+    #         - sr_eq_nemitt_zeta: longitudinal equilibrium normalized emittance from synchrotron radiation used, in [m]
     # ----------------------------------------------------------------------------------------------
     # TODO: Perform check for valid value of emittance_constraint but no value of emittance coupling factor
     # ----------------------------------------------------------------------------------------------

--- a/xfields/ibs/_equilibrium_emittance.py
+++ b/xfields/ibs/_equilibrium_emittance.py
@@ -59,7 +59,7 @@ class EmittanceTimeDerivatives(xo.HybridClass):
 
 def _ibs_rates_and_emittance_derivatives(
     twiss: xt.TwissTable,
-    bunch_intensity: float,  # TODO: rename total_beam_intensity like in rest of APIs, confirm Seb is ok
+    total_beam_intensity: int,
     input_emittances: tuple[float, float, float],
     formalism: Literal["Nagaitsev", "Bjorken-Mtingwa", "B&M"] = "Nagaitsev",
     longitudinal_emittance_ratio: float = None,
@@ -73,8 +73,8 @@ def _ibs_rates_and_emittance_derivatives(
     ----------
     twiss : xtrack.TwissTable
         Twiss results of the `xtrack.Line` configuration.
-    bunch_intensity : float
-        Bunch intensity [particles per bunch].
+    total_beam_intensity : int
+        The beam or bunch intensity, in [particles per bunch].
     input_emittances : tuple[float, float, float]
         The bunch's starting geometric emittances in the horizontal,
         vertical and longitudinal planes, in [m].
@@ -127,7 +127,7 @@ def _ibs_rates_and_emittance_derivatives(
     # Ask to compute the IBS growth rates (this function logs so no need to do it here)
     ibs_growth_rates = twiss.get_ibs_growth_rates(
         formalism=formalism,
-        total_beam_intensity=bunch_intensity,
+        total_beam_intensity=total_beam_intensity,
         gemitt_x=input_emittance_x,
         gemitt_y=input_emittance_y,
         sigma_delta=sigma_delta,
@@ -161,7 +161,7 @@ def _ibs_rates_and_emittance_derivatives(
 
 def compute_emittance_evolution(
     twiss: xt.TwissTable,
-    bunch_intensity: float,
+    total_beam_intensity: int,
     initial_emittances: tuple = None,
     emittance_coupling_factor: float = 0,
     emittance_constraint: Literal["Coupling", "Excitation"] = "Coupling",
@@ -185,8 +185,8 @@ def compute_emittance_evolution(
     ----------
     twiss : object
         Twiss object of the ring.
-    bunch_intensity : float
-        Bunch intensity [particles per bunch].
+    total_beam_intensity : int
+        The beam or bunch intensity, in [particles per bunch].
     initial_emittances : tuple of floats, optional
         Initial values for the horizontal, vertical, and longitudinal
         emittances. If None, the equilibrium emittances from the Twiss object
@@ -306,7 +306,7 @@ def compute_emittance_evolution(
         # Compute IBS growth rates and emittance derivatives
         ibs_growth_rates, emittance_derivatives = _ibs_rates_and_emittance_derivatives(
             twiss,
-            bunch_intensity,
+            total_beam_intensity,
             current_emittances,
             initial_emittances=initial_emittances,
             emittance_coupling_factor=emittance_coupling_factor,

--- a/xfields/ibs/_equilibrium_emittance.py
+++ b/xfields/ibs/_equilibrium_emittance.py
@@ -302,13 +302,13 @@ def compute_emittance_evolution(
     sigma_delta = (emittance_z / twiss.bets0) ** 0.5
     if sigma_zeta is not None:
         warnings.warn(
-            "'input_sigma_zeta' is specified, make sure it remains "
+            "'sigma_zeta' is specified, make sure it remains "
             "consistent with 'initial_emittances'."
         )
         sigma_zeta = sigma_zeta
     elif sigma_delta is not None:
         warnings.warn(
-            "'input_sigma_delta' is specified, make sure it remains "
+            "'sigma_delta' is specified, make sure it remains "
             "consistent with 'initial_emittances'."
         )
         sigma_delta = sigma_delta

--- a/xfields/ibs/_equilibrium_emittance.py
+++ b/xfields/ibs/_equilibrium_emittance.py
@@ -59,9 +59,9 @@ class EmittanceTimeDerivatives(xo.HybridClass):
 
 def _ibs_rates_and_emittance_derivatives(
     twiss: xt.TwissTable,
+    formalism: Literal["Nagaitsev", "Bjorken-Mtingwa", "B&M"],
     total_beam_intensity: int,
     input_emittances: tuple[float, float, float],
-    formalism: Literal["Nagaitsev", "Bjorken-Mtingwa", "B&M"] = "Nagaitsev",
     longitudinal_emittance_ratio: float = None,
     **kwargs,
 ) -> tuple[IBSGrowthRates, EmittanceTimeDerivatives]:
@@ -73,15 +73,15 @@ def _ibs_rates_and_emittance_derivatives(
     ----------
     twiss : xtrack.TwissTable
         Twiss results of the `xtrack.Line` configuration.
+    formalism : str
+        Which formalism to use for the computation of the IBS growth rates.
+        Can be ``Nagaitsev`` or ``Bjorken-Mtingwa`` (also accepts ``B&M``),
+        case-insensitively.
     total_beam_intensity : int
         The beam or bunch intensity, in [particles per bunch].
     input_emittances : tuple[float, float, float]
         The bunch's starting geometric emittances in the horizontal,
         vertical and longitudinal planes, in [m].
-    formalism : str
-        Which formalism to use for the computation of the IBS growth rates.
-        Can be ``Nagaitsev`` or ``Bjorken-Mtingwa`` (also accepts ``B&M``),
-        case-insensitively.
     longitudinal_emittance_ratio : float, optional
         Ratio of the RMS bunch length to the RMS momentum spread. If provided,
         allows accounting for a perturbed longitudinal distrubtion due to

--- a/xfields/ibs/_equilibrium_emittance.py
+++ b/xfields/ibs/_equilibrium_emittance.py
@@ -212,8 +212,9 @@ def compute_emittance_evolution(
         SR equilibrium emittances from the TwissTable are used. Defaults
         to `None`.
     emittance_coupling_factor : float, optional
-        A factor relating vertical to horizontal emittances. If a value is
-        provided, it is taken into account for the evolution of emittances.
+        The ratio of perturbed transverse emittances due to betatron coupling.
+        If a value is provided, it is taken into account for the evolution of
+        emittances and induced an emittance sharing between the two planes.
         See the next parameter for possible scenarios and how this value is
         used. Defaults to 0.
     emittance_constraint : str, optional
@@ -285,6 +286,8 @@ def compute_emittance_evolution(
     #         - sr_eq_gemitt_x: horizontal equilibrium geometric emittance from synchrotron radiation used, in [m]
     #         - sr_eq_gemitt_y: vertical equilibrium geometric emittance from synchrotron radiation used, in [m]
     #         - eq_nemitt_zeta: longitudinal equilibrium normalized emittance from synchrotron radiation used, in [m]
+    # ----------------------------------------------------------------------------------------------
+    # TODO: Perform check for valid value of emittance_constraint but no value of emittance coupling factor
     # ----------------------------------------------------------------------------------------------
     # Handle initial transverse emittances and potential effect of coupling / excitation constraints
     # TODO: I don't like this, would rather force the user to provide gemitt_x, gemitt_y & gemitt_zeta

--- a/xfields/ibs/_equilibrium_emittance.py
+++ b/xfields/ibs/_equilibrium_emittance.py
@@ -212,9 +212,10 @@ def compute_emittance_evolution(
         SR equilibrium emittances from the TwissTable are used. Defaults
         to `None`.
     emittance_coupling_factor : float, optional
-        The ratio of vertical to horizontal emittances. If a value is provided
-        it is taken into account for the evolution of emittances. See the next
-        parameter for possible scenarios. Defaults to 0.
+        A factor relating vertical to horizontal emittances. If a value is
+        provided, it is taken into account for the evolution of emittances.
+        See the next parameter for possible scenarios and how this value is
+        used. Defaults to 0.
     emittance_constraint : str, optional
         If an accepted value is provided, enforces constraints on the transverse
         emittances. Can be either "coupling" or "excitation", case-insensitively.

--- a/xfields/ibs/_equilibrium_emittance.py
+++ b/xfields/ibs/_equilibrium_emittance.py
@@ -165,6 +165,7 @@ def _ibs_rates_and_emittance_derivatives(
 
 def compute_emittance_evolution(
     twiss: xt.TwissTable,
+    formalism: Literal["Nagaitsev", "Bjorken-Mtingwa", "B&M"],
     total_beam_intensity: int,
     initial_emittances: tuple = None,
     emittance_coupling_factor: float = 0,
@@ -189,6 +190,10 @@ def compute_emittance_evolution(
     ----------
     twiss : object
         Twiss object of the ring.
+    formalism : str
+        Which formalism to use for the computation of the IBS growth rates.
+        Can be ``Nagaitsev`` or ``Bjorken-Mtingwa`` (also accepts ``B&M``),
+        case-insensitively.
     total_beam_intensity : int
         The beam or bunch intensity, in [particles per bunch].
     initial_emittances : tuple of floats, optional


### PR DESCRIPTION
Mostly cosmetics this time again, with changes focused on the public function.

Notable:
- Moved up `formalism` parameter in private function to mimic the IBS growth rates API
- Removed default value of `formalism` parameter
- Added `formalism` parameter to public function so the user **gets to choose!**
- Renamed `bunch_intensity` parameter to `total_beam_intensity` to mimic IBS growth rates API (I know it's not better but it's how it is, let's have the same everywhere)
- Propagated `kwargs` from public function to private function to IBS growth rates calculation
- Added some commented-out code for future API changes (to be discussed in person)
- Heavily reworked docstrings information of public function, removing parts for deleted parameters and being explicit about the meaning / behaviour of various elements
- Renamed `input_sigma_[delta,zeta]` to `override_sigma_[delta,zeta]` to be explicit
- Started adding some walkthrough comments


I have ran the script I put in #1 on your branch to check values. Due to slightly different API (adding `formalism`, renaming params etc) I have ran the following on my branch (you can check it is equivalent):
```python
import xtrack as xt
from scipy.constants import e

import xfields as xf

# Load line and build tracker
line = xt.Line.from_json("bessy3.json")
line.build_tracker()

# Prepare radiation mode and twiss
line.matrix_stability_tol = 1e-2
line.configure_radiation(model="mean")
line.compensate_radiation_energy_loss()
twiss = line.twiss(eneloss_and_damping=True)


# Compute emittance evolution to convergence
bunch_intensity = 1e-9 / e  # 1C bunch intensity
emittance_coupling_factor = 1
time, emittances_x_list, emittances_y_list, emittances_z_list, T_x, T_y, T_z = (
    xf.ibs.compute_emittance_evolution(
        twiss=twiss,
        formalism="Nagaitsev",  # default in seb's version
        total_beam_intensity=bunch_intensity,
        initial_emittances=None,
        emittance_coupling_factor=emittance_coupling_factor,
        emittance_constraint="coupling",
        rtol=1e-6,
    )
)


# Checks prints
factor = 1 + emittance_coupling_factor * (twiss.partition_numbers[1] / twiss.partition_numbers[0])
# epsilon_x
print(
    emittances_x_list[-1],
    emittances_x_list[0] / (1 - T_x[-1] / 2 / (twiss.damping_constants_s[0] * factor)),
)
# epsilon_y
print(
    emittances_y_list[-1],
    emittances_y_list[0] / (1 - T_x[-1] / 2 / (twiss.damping_constants_s[0] * factor)),
)
# epsilon_z
print(
    emittances_z_list[-1], emittances_z_list[0] / (1 - T_z[-1] / 2 / (twiss.damping_constants_s[2]))
)
```

Once again, results for both branches below:

| Converged Value  |      Your Branch      |       My Branch       |       Analytical      |
| ---------------- | --------------------- | --------------------- | --------------------- |
|     gemitt_x     | 8.449152285724216e-11 | 8.449152285724216e-11 | 8.450153188597292e-11 |
|     gemitt_y     | 8.449152285724216e-11 | 8.449152285724216e-11 | 8.450153188597292e-11 |
|    gemitt_zeta   | 4.517867740266872e-06 | 4.517867740266872e-06 | 4.519061552568138e-06 |

No surprises as calculations are untouched but good to confirm that we are still all good.