### PR TITLE
First batch of API and behaviour changes

### DIFF
--- a/tests/test_ibs_equilibrium_emittances.py
+++ b/tests/test_ibs_equilibrium_emittances.py
@@ -25,7 +25,7 @@ def test_ibs_emittance_constraints(emittance_constraint):
 
     emittance_coupling_factor = 0.02
 
-    time, emittances_x_list, emittances_y_list, emittances_z_list, T_x, T_y, T_z = xf.ibs.compute_emittance_evolution(
+    time, emittances_x_list, emittances_y_list, emittances_z_list, T_x, T_y, T_z = xf.ibs.compute_equilibrium_emittances_from_sr_and_ibs(
         twiss, bunch_intensity,
         emittance_coupling_factor=emittance_coupling_factor,
         emittance_constraint=emittance_constraint,
@@ -82,7 +82,7 @@ def test_ibs_emittance_coupling_factor(emittance_coupling_factor):
     # Equilibrium emittances calculations #
     #######################################
 
-    time, emittances_x_list, emittances_y_list, emittances_z_list, T_x, T_y, T_z = xf.ibs.compute_emittance_evolution(
+    time, emittances_x_list, emittances_y_list, emittances_z_list, T_x, T_y, T_z = xf.ibs.compute_equilibrium_emittances_from_sr_and_ibs(
         twiss, bunch_intensity,
         emittance_coupling_factor=emittance_coupling_factor,
     )
@@ -126,7 +126,7 @@ def test_ibs_emittance_no_constraint(emittance_coupling_factor):
     # Equilibrium emittances calculations #
     #######################################
 
-    time, emittances_x_list, emittances_y_list, emittances_z_list, T_x, T_y, T_z = xf.ibs.compute_emittance_evolution(
+    time, emittances_x_list, emittances_y_list, emittances_z_list, T_x, T_y, T_z = xf.ibs.compute_equilibrium_emittances_from_sr_and_ibs(
         twiss, bunch_intensity,
         initial_emittances=initial_emittances,
         emittance_coupling_factor=emittance_coupling_factor,

--- a/xfields/ibs/__init__.py
+++ b/xfields/ibs/__init__.py
@@ -6,13 +6,13 @@
 from ._analytical import BjorkenMtingwaIBS, IBSGrowthRates, NagaitsevIBS
 from ._api import configure_intrabeam_scattering, get_intrabeam_scattering_growth_rates
 from ._kicks import IBSAnalyticalKick, IBSKineticKick
-from ._equilibrium import compute_emittance_evolution
+from ._equilibrium import compute_equilibrium_emittances_from_sr_and_ibs
 
 __all__ = [
     "BjorkenMtingwaIBS",
     "configure_intrabeam_scattering",
     "get_intrabeam_scattering_growth_rates",
-    "compute_emittance_evolution",
+    "compute_equilibrium_emittances_from_sr_and_ibs",
     "IBSGrowthRates",
     "IBSAnalyticalKick",
     "IBSKineticKick",

--- a/xfields/ibs/__init__.py
+++ b/xfields/ibs/__init__.py
@@ -5,8 +5,8 @@
 
 from ._analytical import BjorkenMtingwaIBS, IBSGrowthRates, NagaitsevIBS
 from ._api import configure_intrabeam_scattering, get_intrabeam_scattering_growth_rates
-from ._kicks import IBSAnalyticalKick, IBSKineticKick
 from ._equilibrium import compute_equilibrium_emittances_from_sr_and_ibs
+from ._kicks import IBSAnalyticalKick, IBSKineticKick
 
 __all__ = [
     "BjorkenMtingwaIBS",

--- a/xfields/ibs/__init__.py
+++ b/xfields/ibs/__init__.py
@@ -10,9 +10,9 @@ from ._kicks import IBSAnalyticalKick, IBSKineticKick
 
 __all__ = [
     "BjorkenMtingwaIBS",
+    "compute_equilibrium_emittances_from_sr_and_ibs",
     "configure_intrabeam_scattering",
     "get_intrabeam_scattering_growth_rates",
-    "compute_equilibrium_emittances_from_sr_and_ibs",
     "IBSGrowthRates",
     "IBSAnalyticalKick",
     "IBSKineticKick",

--- a/xfields/ibs/_equilibrium.py
+++ b/xfields/ibs/_equilibrium.py
@@ -166,11 +166,10 @@ def compute_equilibrium_emittances_from_sr_and_ibs(
     # nemitt_y: float = None,
     # gemitt_zeta: float = None,
     # nemitt_zeta: float = None,
-    emittance_coupling_factor: float = 0,
-    emittance_constraint: Literal["coupling", "excitation"] = "coupling",
-    # TODO: move these two (still optional) below gemitt_x, gemitt_y, gemitt_zeta when modify that
     overwrite_sigma_zeta: float = None,
     overwrite_sigma_delta: float = None,
+    emittance_coupling_factor: float = 0,
+    emittance_constraint: Literal["coupling", "excitation"] = "coupling",
     rtol: float = 1e-6,
     verbose: bool = True,
     **kwargs,

--- a/xfields/ibs/_equilibrium.py
+++ b/xfields/ibs/_equilibrium.py
@@ -100,16 +100,12 @@ def _ibs_rates_and_emittance_derivatives(
     """
     LOGGER.debug("Computing IBS growth rates and emittance time derivatives.")
     # ----------------------------------------------------------------------------------------------
-    # TODO: bunch emittances - ask for the three separately and update docstring
+    # TODO: bunch emittances - ask for the three separately and update docstring - keep checks here
     input_emittance_x, input_emittance_y, input_emittance_z = input_emittances
-    assert input_emittance_x > 0.0, (
-        "'input_emittance_x' should be larger than zero, try providing 'initial_emittances'"
-    )
-    assert input_emittance_y > 0.0, (
-        "'input_emittance_y' should be larger than zero, try providing 'initial_emittances'"
-    )
+    assert input_emittance_x > 0.0, "'input_emittance_x' should be larger than zero"
+    assert input_emittance_y > 0.0, "'input_emittance_y' should be larger than zero"
     # ----------------------------------------------------------------------------------------------
-    # TODO: check for SR eq emittances etc in twiss table (or in public func?) Could be:
+    # TODO: check for SR eq emittances etc in twiss table (or in public func?) (move to main func)
     # if None in (
     #     getattr(twiss, "eq_gemitt_x", None),
     #     getattr(twiss, "eq_gemitt_y", None),
@@ -305,10 +301,14 @@ def compute_emittance_evolution(
     sigma_zeta = (emittance_z * twiss.bets0) ** 0.5
     sigma_delta = (emittance_z / twiss.bets0) ** 0.5
     if overwrite_sigma_zeta is not None:
-        warnings.warn("'overwrite_sigma_zeta' is specified, make sure it remains consistent with 'initial_emittances'.")
+        warnings.warn(
+            "'overwrite_sigma_zeta' is specified, make sure it remains consistent with 'initial_emittances'."
+        )
         sigma_zeta = overwrite_sigma_zeta
     elif overwrite_sigma_delta is not None:
-        warnings.warn("'sigma_delta' is specified, make sure it remains consistent with 'initial_emittances'.")
+        warnings.warn(
+            "'sigma_delta' is specified, make sure it remains consistent with 'initial_emittances'."
+        )
         sigma_delta = overwrite_sigma_delta
     longitudinal_emittance_ratio = sigma_zeta / sigma_delta
     if overwrite_sigma_zeta is not None or overwrite_sigma_delta is not None:
@@ -336,7 +336,9 @@ def compute_emittance_evolution(
     # - Compute tolerance and check for convergence
     while tolerance > rtol:
         if verbose is True:  # Display estimated convergence progress if asked
-            xo.general._print(f"Iteration {iterations} - convergence = {100 * rtol / tolerance:.1f}%", end="\r")
+            xo.general._print(
+                f"Iteration {iterations} - convergence = {100 * rtol / tolerance:.1f}%", end="\r"
+            )
 
         # Compute IBS growth rates and emittance derivatives
         ibs_growth_rates, emittance_derivatives = _ibs_rates_and_emittance_derivatives(
@@ -378,7 +380,9 @@ def compute_emittance_evolution(
 
         # Compute tolerance (but not at first step since there is no previous value)
         if iterations > 0:
-            tolerance = np.max(np.abs((current_emittances - previous_emittances) / previous_emittances))
+            tolerance = np.max(
+                np.abs((current_emittances - previous_emittances) / previous_emittances)
+            )
 
         # Store current emittances for the next iteration
         previous_emittances = current_emittances.copy()
@@ -389,16 +393,16 @@ def compute_emittance_evolution(
         iterations += 1
     # ----------------------------------------------------------------------------------------------
     # We have exited the loop, we have converged. Construct a Table with the results and return it
-    xo.general._print(f"Converged to equilibrium with a tolerance of {tolerance:.4e}")
+    xo.general._print(f"Reached equilibrium with tolerance={tolerance:.2e} (vs rtol={rtol:.2e})")
     result_table = Table(
         data={
-            "time": np.cumsum(time),
-            "gemitt_x": res_gemitt_x,
-            "gemitt_y": res_gemitt_y,
-            "gemitt_zeta": res_gemitt_zeta,
-            "Tx": T_x,
-            "Ty": T_y,
-            "Tz": T_z,
+            "time": np.cumsum(time_deltas),
+            "gemitt_x": np.array(res_gemitt_x),
+            "gemitt_y": np.array(res_gemitt_y),
+            "gemitt_zeta": np.array(res_gemitt_zeta),
+            "Tx": np.array(T_x),
+            "Ty": np.array(T_y),
+            "Tz": np.array(T_z),
         },
         index="time",
     )

--- a/xfields/ibs/_equilibrium.py
+++ b/xfields/ibs/_equilibrium.py
@@ -260,6 +260,8 @@ def compute_equilibrium_emittances_from_sr_and_ibs(
             - gemitt_x: horizontal geometric emittance values, in [m].
             - gemitt_y: vertical geometric emittance values, in [m].
             - gemitt_zeta: longitudinal geometric emittance values, in [m].
+            - sigma_zeta: bunch length values, in [m].
+            - sigma_delta: momentum spread values, in [-].
             - Tx: horizontal IBS growth rate, in [s^-1].
             - Ty: vertical IBS growth rate, in [s^-1].
             - Tz: longitudinal IBS growth rate, in [s^-1].
@@ -440,7 +442,7 @@ def compute_equilibrium_emittances_from_sr_and_ibs(
             "gemitt_x": np.array(res_gemitt_x),
             "gemitt_y": np.array(res_gemitt_y),
             "gemitt_zeta": np.array(res_gemitt_zeta),
-            "sigma_zeta": np.sqrt(np.array(res_gemitt_zeta) * twiss.bets0) ,
+            "sigma_zeta": np.sqrt(np.array(res_gemitt_zeta) * twiss.bets0),
             "sigma_delta": np.sqrt(np.array(res_gemitt_zeta) / twiss.bets0),
             "Tx": np.array(T_x),
             "Ty": np.array(T_y),

--- a/xfields/ibs/_equilibrium.py
+++ b/xfields/ibs/_equilibrium.py
@@ -6,16 +6,20 @@
 from __future__ import annotations
 
 import logging
-from typing import Literal
+from typing import TYPE_CHECKING
 
 import numpy as np
 import xobjects as xo
 import xtrack as xt
-from numpy.typing import ArrayLike
 from xobjects.general import _print
 from xtrack import Table
 
-from xfields.ibs._analytical import IBSGrowthRates
+if TYPE_CHECKING:
+    from typing import Literal
+
+    from numpy.typing import ArrayLike
+
+    from xfields.ibs._analytical import IBSGrowthRates
 
 LOGGER = logging.getLogger(__name__)
 

--- a/xfields/ibs/_equilibrium.py
+++ b/xfields/ibs/_equilibrium.py
@@ -349,13 +349,19 @@ def compute_equilibrium_emittances_from_sr_and_ibs(
         # Since a longitudinal property was overwritten we recompute the emittance_z
         emittance_z = sigma_zeta * sigma_delta
     # ----------------------------------------------------------------------------------------------
-    # Start structures to store the iterative results until convergence
+    # Initialize values for the iterative process (first time step is revolution period)
+    iterations = 0
     tolerance = np.inf
-    time_step = twiss.T_rev0  # Initial time step is the revolution period
-
-    time_deltas = []
-    res_gemitt_x, res_gemitt_y, res_gemitt_zeta = [], [], []
-    T_x, T_y, T_z = [], [], []
+    time_step = twiss.T_rev0
+    # Structures for iterative results (time, IBS growth rates, computed emittances)
+    time_deltas = []  # stores the deltas (!), we do a cumsum at the end
+    T_x = []
+    T_y = []
+    T_z = []
+    res_gemitt_x = []
+    res_gemitt_y = []
+    res_gemitt_zeta = []
+    # Starting emittances (numpy array since we compute the next ones from these)
     current_emittances = np.array([emittance_x, emittance_y, emittance_z])
     # ----------------------------------------------------------------------------------------------
     # Start the iterative process until convergence:

--- a/xfields/ibs/_equilibrium.py
+++ b/xfields/ibs/_equilibrium.py
@@ -12,6 +12,7 @@ from typing import Literal
 import numpy as np
 import xobjects as xo
 import xtrack as xt
+from numpy.typing import ArrayLike
 from xtrack import Table
 
 from xfields.ibs._analytical import IBSGrowthRates
@@ -350,19 +351,19 @@ def compute_equilibrium_emittances_from_sr_and_ibs(
         emittance_z = sigma_zeta * sigma_delta
     # ----------------------------------------------------------------------------------------------
     # Initialize values for the iterative process (first time step is revolution period)
-    iterations = 0
-    tolerance = np.inf
-    time_step = twiss.T_rev0
+    iterations: float = 0
+    tolerance: float = np.inf
+    time_step: float = twiss.T_rev0
     # Structures for iterative results (time, IBS growth rates, computed emittances)
-    time_deltas = []  # stores the deltas (!), we do a cumsum at the end
-    T_x = []
-    T_y = []
-    T_z = []
-    res_gemitt_x = []
-    res_gemitt_y = []
-    res_gemitt_zeta = []
+    time_deltas: list[float] = []  # stores the deltas (!), we do a cumsum at the end
+    T_x: list[float] = []
+    T_y: list[float] = []
+    T_z: list[float] = []
+    res_gemitt_x: list[float] = []
+    res_gemitt_y: list[float] = []
+    res_gemitt_zeta: list[float] = []
     # Starting emittances (numpy array since we compute the next ones from these)
-    current_emittances = np.array([emittance_x, emittance_y, emittance_z])
+    current_emittances: ArrayLike = np.array([emittance_x, emittance_y, emittance_z])
     # ----------------------------------------------------------------------------------------------
     # Start the iterative process until convergence:
     # - Compute IBS rates and emittance time derivatives
@@ -409,12 +410,12 @@ def compute_equilibrium_emittances_from_sr_and_ibs(
 
         # Append current values to lists
         time_deltas.append(time_step)
-        res_gemitt_x.append(current_emittances[0])
-        res_gemitt_y.append(current_emittances[1])
-        res_gemitt_zeta.append(current_emittances[2])
         T_x.append(ibs_growth_rates[0])
         T_y.append(ibs_growth_rates[1])
         T_z.append(ibs_growth_rates[2])
+        res_gemitt_x.append(current_emittances[0])
+        res_gemitt_y.append(current_emittances[1])
+        res_gemitt_zeta.append(current_emittances[2])
 
         # Compute tolerance (but not at first step since there is no previous value)
         if iterations > 0:

--- a/xfields/ibs/_equilibrium.py
+++ b/xfields/ibs/_equilibrium.py
@@ -324,11 +324,11 @@ def compute_equilibrium_emittances_from_sr_and_ibs(
         )
         # If emittance_coupling_factor is non zero, then natural emittance is modified accordingly (used
         # convention is valid for arbitrary damping partition numbers and emittance_coupling_factor).
-        if emittance_coupling_factor != 0 and emittance_constraint.lower() == "coupling":
+        if emittance_constraint.lower() == "coupling" and emittance_coupling_factor != 0:
             emittance_y = emittance_x * emittance_coupling_factor / (1 + emittance_coupling_factor * twiss.partition_numbers[1] / twiss.partition_numbers[0])
             emittance_x *= 1 / (1 + emittance_coupling_factor * twiss.partition_numbers[1] / twiss.partition_numbers[0])
 
-        if emittance_coupling_factor != 0 and emittance_constraint.lower() == "excitation":
+        if emittance_constraint.lower() == "excitation" and emittance_coupling_factor != 0:
             # The convention used only enforce a constraint on the vertical
             # emittance
             emittance_y = emittance_x * emittance_coupling_factor

--- a/xfields/ibs/_equilibrium.py
+++ b/xfields/ibs/_equilibrium.py
@@ -266,12 +266,12 @@ def compute_emittance_evolution(
         The table also contains the following global quantities:
             - damping_constants_s: radiation damping constants per second used for the calculations
             - partition_numbers: damping partition numbers used for the calculations
-            - eq_gemitt_x: final horizontal equilibrium geometric emittance converged to, in [m]
-            - eq_gemitt_y: final vertical equilibrium geometric emittance converged to, in [m]
-            - eq_gemitt_zeta: final longitudinal equilibrium geometric emittance converged to, in [m]
-            - sr_eq_gemitt_x: horizontal equilibrium geometric emittance from synchrotron radiation used, in [m]
-            - sr_eq_gemitt_y: vertical equilibrium geometric emittance from synchrotron radiation used, in [m]
-            - sr_eq_nemitt_zeta: longitudinal equilibrium normalized emittance from synchrotron radiation used, in [m]
+            - eq_gemitt_x: horizontal equilibrium geometric emittance from synchrotron radiation used, in [m]
+            - eq_gemitt_y: vertical equilibrium geometric emittance from synchrotron radiation used, in [m]
+            - eq_nemitt_zeta: longitudinal equilibrium normalized emittance from synchrotron radiation used, in [m]
+            - sr_ibs_eq_gemitt_x: final horizontal equilibrium geometric emittance converged to, in [m]
+            - sr_ibs_eq_gemitt_y: final vertical equilibrium geometric emittance converged to, in [m]
+            - sr_ibs_eq_gemitt_zeta: final longitudinal equilibrium geometric emittance converged to, in [m]
     """
     # ----------------------------------------------------------------------------------------------
     # TODO: Perform check for valid value of emittance_constraint but no value of emittance coupling factor
@@ -407,12 +407,12 @@ def compute_emittance_evolution(
         {
             "damping_constants_s": twiss.damping_constants_s,
             "partition_numbers": twiss.partition_numbers,
-            "eq_gemitt_x": res_gemitt_x[-1],
-            "eq_gemitt_x": res_gemitt_y[-1],
-            "eq_gemitt_x": res_gemitt_zeta[-1],
-            "sr_eq_gemitt_x": twiss.eq_gemitt_x,
-            "sr_eq_gemitt_y": twiss.eq_gemitt_y,
-            "eq_nemitt_zeta": twiss.eq_nemitt_zeta,
+            "sr_ibs_eq_gemitt_x": res_gemitt_x[-1],
+            "sr_ibs_eq_gemitt_y": res_gemitt_y[-1],
+            "sr_ibs_eq_gemitt_zeta": res_gemitt_zeta[-1],
+            "eq_gemitt_x": twiss.eq_gemitt_x,
+            "eq_gemitt_y": twiss.eq_gemitt_y,
+            "eq_gemitt_zeta": twiss.eq_gemitt_zeta,
         }
     )
     return result_table

--- a/xfields/ibs/_equilibrium.py
+++ b/xfields/ibs/_equilibrium.py
@@ -366,6 +366,7 @@ def compute_equilibrium_emittances_from_sr_and_ibs(
             "not of 'initial_emittances'. Please provide 'initial_emittances'."
         )
         # Since a longitudinal property was overwritten we recompute the emittance_z
+        LOGGER.warning("At least one longitudinal property overwritten, recomputing longitudinal emittance.")
         emittance_z = sigma_zeta * sigma_delta
     # ---------------------------------------------------------------------------------------------
     # Initialize values for the iterative process (first time step is revolution period)

--- a/xfields/ibs/_equilibrium.py
+++ b/xfields/ibs/_equilibrium.py
@@ -129,7 +129,6 @@ def _ibs_rates_and_emittance_derivatives(
     # ----------------------------------------------------------------------------------------------
     # Computing the emittance time derivatives analytically.
     # TODO: ADD A REF TO THE FORMULA HERE
-    # TODO: replace input_emittance_[xyz] by gemitt_[xyz] once they are parameters
     LOGGER.debug("Computing emittance time derivatives analytically.")
     depsilon_x_dt = (
         -2 * twiss.damping_constants_s[0] * (gemitt_x - twiss.eq_gemitt_x)

--- a/xfields/ibs/_equilibrium.py
+++ b/xfields/ibs/_equilibrium.py
@@ -275,7 +275,7 @@ def compute_equilibrium_emittances_from_sr_and_ibs(
             - Ty: vertical IBS growth rate, in [s^-1].
             - Tz: longitudinal IBS growth rate, in [s^-1].
         The table also contains the following global quantities:
-            - damping_constants_s: radiation damping constants per second used.
+            - damping_constants_s: radiation damping constants used, in [s^-1].
             - partition_numbers: damping partition numbers used.
             - eq_gemitt_x: horizontal equilibrium geometric emittance from synchrotron radiation used, in [m].
             - eq_gemitt_y: vertical equilibrium geometric emittance from synchrotron radiation used, in [m].

--- a/xfields/ibs/_equilibrium.py
+++ b/xfields/ibs/_equilibrium.py
@@ -182,17 +182,23 @@ def compute_equilibrium_emittances_from_sr_and_ibs(
     verbose: bool = True,
     **kwargs,
 ) -> Table:
-    # TODO: rework this main chunk of docstring
     """
-    Compute the evolution of beam emittances due to IBS until convergence.
-    By default, the function assumes the emittances from the Twiss object.
-    They can also be specified as well as different natural emittances.
-    The emittance evolution can be constrained to follow two scenarios:
-        - A vertical emittance originating from linear coupling.
+    Compute the evolution of emittances due to Synchrotron Radiation
+    and Intra-Beam Scattering until convergence to equilibrium values.
+    The equilibrium state is determined by an iterative process which
+    consists in computing the IBS growth rates and the emittance time
+    derivaties, then computing the emittances at the next time step,
+    potentially including the effect of transverse constraints, and
+    checking for convergence. The convergence criteria can be chosen
+    by the user.
+
+    Transverse emittances can be constrained to follow two scenarios:
+        - An emittance exchange originating from betatron coupling.
         - A vertical emittance originating from an excitation.
-    The impact from the longitudinal impedance (e.g. bunch lengthening or
-    microwave instability) can be accounted for by specifying the RMS bunch
-    length and momentum spread.
+
+    The impact from the longitudinal impedance (e.g. bunch lengthening
+    or microwave instability) can be accounted for by specifying the RMS
+    bunch length and momentum spread.
 
     Parameters
     ----------
@@ -251,7 +257,7 @@ def compute_equilibrium_emittances_from_sr_and_ibs(
 
     Returns
     -------
-    xtrack.TwissTable
+    xtrack.Table
         The convergence calculations results. The table contains the following
         columns, as time-step by time-step quantities:
             - time: time values at which quantities are computed, in [s].

--- a/xfields/ibs/_equilibrium.py
+++ b/xfields/ibs/_equilibrium.py
@@ -158,8 +158,10 @@ def _ibs_rates_and_emittance_derivatives(
     )
 
 
-# TODO: find a better, more explicit name for this
-def compute_emittance_evolution(
+# ----- Public API (to be integrated as method in TwissTable) ----- #
+
+
+def compute_equilibrium_emittances_from_sr_and_ibs(
     twiss: xt.TwissTable,
     formalism: Literal["Nagaitsev", "Bjorken-Mtingwa", "B&M"],
     total_beam_intensity: int,
@@ -252,22 +254,22 @@ def compute_emittance_evolution(
     xtrack.TwissTable
         The convergence calculations results. The table contains the following
         columns, as time-step by time-step quantities:
-            - time: time values at which quantities are computed, in [s]
-            - gemitt_x: horizontal geometric emittance values, in [m]
-            - gemitt_y: vertical geometric emittance values, in [m]
-            - gemitt_zeta: longitudinal geometric emittance values, in [m]
-            - Tx: horizontal IBS growth rate, in [s^-1]
-            - Ty: vertical IBS growth rate, in [s^-1]
-            - Tz: longitudinal IBS growth rate, in [s^-1]
+            - time: time values at which quantities are computed, in [s].
+            - gemitt_x: horizontal geometric emittance values, in [m].
+            - gemitt_y: vertical geometric emittance values, in [m].
+            - gemitt_zeta: longitudinal geometric emittance values, in [m].
+            - Tx: horizontal IBS growth rate, in [s^-1].
+            - Ty: vertical IBS growth rate, in [s^-1].
+            - Tz: longitudinal IBS growth rate, in [s^-1].
         The table also contains the following global quantities:
-            - damping_constants_s: radiation damping constants per second used for the calculations
-            - partition_numbers: damping partition numbers used for the calculations
-            - eq_gemitt_x: horizontal equilibrium geometric emittance from synchrotron radiation used, in [m]
-            - eq_gemitt_y: vertical equilibrium geometric emittance from synchrotron radiation used, in [m]
-            - eq_nemitt_zeta: longitudinal equilibrium normalized emittance from synchrotron radiation used, in [m]
-            - sr_ibs_eq_gemitt_x: final horizontal equilibrium geometric emittance converged to, in [m]
-            - sr_ibs_eq_gemitt_y: final vertical equilibrium geometric emittance converged to, in [m]
-            - sr_ibs_eq_gemitt_zeta: final longitudinal equilibrium geometric emittance converged to, in [m]
+            - damping_constants_s: radiation damping constants per second used.
+            - partition_numbers: damping partition numbers used.
+            - eq_gemitt_x: horizontal equilibrium geometric emittance from synchrotron radiation used, in [m].
+            - eq_gemitt_y: vertical equilibrium geometric emittance from synchrotron radiation used, in [m].
+            - eq_gemitt_zeta: longitudinal equilibrium geometric emittance from synchrotron radiation used, in [m].
+            - sr_ibs_eq_gemitt_x: final horizontal equilibrium geometric emittance converged to, in [m].
+            - sr_ibs_eq_gemitt_y: final vertical equilibrium geometric emittance converged to, in [m].
+            - sr_ibs_eq_gemitt_zeta: final longitudinal equilibrium geometric emittance converged to, in [m].
     """
     # ----------------------------------------------------------------------------------------------
     # TODO: Perform check for valid value of emittance_constraint but no value of emittance coupling factor
@@ -411,12 +413,12 @@ def compute_emittance_evolution(
         {
             "damping_constants_s": twiss.damping_constants_s,
             "partition_numbers": twiss.partition_numbers,
-            "sr_ibs_eq_gemitt_x": res_gemitt_x[-1],
-            "sr_ibs_eq_gemitt_y": res_gemitt_y[-1],
-            "sr_ibs_eq_gemitt_zeta": res_gemitt_zeta[-1],
             "eq_gemitt_x": twiss.eq_gemitt_x,
             "eq_gemitt_y": twiss.eq_gemitt_y,
             "eq_gemitt_zeta": twiss.eq_gemitt_zeta,
+            "sr_ibs_eq_gemitt_x": res_gemitt_x[-1],
+            "sr_ibs_eq_gemitt_y": res_gemitt_y[-1],
+            "sr_ibs_eq_gemitt_zeta": res_gemitt_zeta[-1],
         }
     )
     return result_table

--- a/xfields/ibs/_equilibrium.py
+++ b/xfields/ibs/_equilibrium.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 import logging
-import warnings
 from typing import Literal
 
 import numpy as np
@@ -313,7 +312,7 @@ def compute_equilibrium_emittances_from_sr_and_ibs(
     # Handle initial transverse emittances and potential effect of coupling / excitation constraints
     # TODO: I don't like this, would rather force the user to provide gemitt_x, gemitt_y & gemitt_zeta
     if initial_emittances is None:
-        print("Emittances from the Twiss object are being used.")
+        _print("Emittances from the Twiss object are being used.")
         emittance_x, emittance_y, emittance_z = (
             twiss.eq_gemitt_x,
             twiss.eq_gemitt_y,
@@ -337,14 +336,10 @@ def compute_equilibrium_emittances_from_sr_and_ibs(
     sigma_zeta = (emittance_z * twiss.bets0) ** 0.5
     sigma_delta = (emittance_z / twiss.bets0) ** 0.5
     if overwrite_sigma_zeta is not None:
-        warnings.warn(
-            "'overwrite_sigma_zeta' is specified, make sure it remains consistent with 'initial_emittances'."
-        )
+        LOGGER.warning("'overwrite_sigma_zeta' is specified, make sure it remains consistent with 'initial_emittances'.")
         sigma_zeta = overwrite_sigma_zeta
     elif overwrite_sigma_delta is not None:
-        warnings.warn(
-            "'sigma_delta' is specified, make sure it remains consistent with 'initial_emittances'."
-        )
+        LOGGER.warning("'sigma_delta' is specified, make sure it remains consistent with 'initial_emittances'.")
         sigma_delta = overwrite_sigma_delta
     longitudinal_emittance_ratio = sigma_zeta / sigma_delta
     if overwrite_sigma_zeta is not None or overwrite_sigma_delta is not None:
@@ -401,9 +396,7 @@ def compute_equilibrium_emittances_from_sr_and_ibs(
         # --------------------------------------------------------------------------
         # Enforce transverse constraint if specified
         if emittance_constraint.lower() == "coupling":
-            forced_emittance_x = (current_emittances[0] + current_emittances[1]) / (
-                1 + emittance_coupling_factor
-            )
+            forced_emittance_x = (current_emittances[0] + current_emittances[1]) / (1 + emittance_coupling_factor)
             forced_emittance_y = forced_emittance_x * emittance_coupling_factor
             current_emittances[0] = forced_emittance_x
             current_emittances[1] = forced_emittance_y

--- a/xfields/ibs/_equilibrium.py
+++ b/xfields/ibs/_equilibrium.py
@@ -244,10 +244,12 @@ def compute_equilibrium_emittances_from_sr_and_ibs(
         effect unless a non-zero factor is provided.
     overwrite_sigma_zeta : float, optional
         The RMS bunch length. If provided, overwrites the one computed from
-        the longitudinal emittance. Defaults to `None`.
+        the longitudinal emittance and forces a recompute of the longitudinal
+        emittance. Defaults to `None`.
     overwrite_sigma_delta : float, optional
         The RMS momentum spread of the bunch. If provided, overwrites the one
-        computed from the longitudinal emittance. Defaults to `None`.
+        computed from the longitudinal emittance and forces a recompute of the
+        longitudinal emittance. Defaults to `None`.
     rtol : float, optional
         Relative tolerance to determine when convergence is reached: if the relative
         difference between the computed emittances and those at the previous step is

--- a/xfields/ibs/_equilibrium.py
+++ b/xfields/ibs/_equilibrium.py
@@ -68,7 +68,8 @@ def _ibs_rates_and_emittance_derivatives(
 ) -> tuple[IBSGrowthRates, EmittanceTimeDerivatives]:
     """
     Compute the IBS growth rates and emittance time derivatives from
-    the effect of both IBS and SR.
+    the effect of both IBS and SR. TODO: Include a ref here to the
+    analytical formula used.
 
     Parameters
     ----------
@@ -109,19 +110,6 @@ def _ibs_rates_and_emittance_derivatives(
     assert gemitt_x > 0.0, "Horizontal emittance should be larger than zero"
     assert gemitt_y > 0.0, "Vertical emittance should be larger than zero"
     assert gemitt_zeta > 0.0, "Longitudinal emittance should be larger than zero"
-    # ----------------------------------------------------------------------------------------------
-    # TODO: check for SR eq emittances etc in twiss table (or in public func?) (move to main func)
-    # if None in (
-    #     getattr(twiss, "eq_gemitt_x", None),
-    #     getattr(twiss, "eq_gemitt_y", None),
-    #     getattr(twiss, "eq_gemitt_zeta", None),
-    #     getattr(twiss, "damping_constants_s", None),
-    # ):
-    #     LOGGER.error("Invalid TwissTable, does not have SR equilibrium properties.")
-    #     raise AttributeError(
-    #         "The TwissTable must contain SR equilibrium emittances and damping constants. "
-    #         "Did you activate radiation and twiss with eneloss_and_damping=True?"
-    #     )
     # ----------------------------------------------------------------------------------------------
     # Compute relevant longitudinal parameters for the bunch (needed for IBS growth rates)
     LOGGER.debug("Computing longitudinal parameters for the bunch.")
@@ -282,6 +270,20 @@ def compute_equilibrium_emittances_from_sr_and_ibs(
             - sr_ibs_eq_gemitt_y: final vertical equilibrium geometric emittance converged to, in [m].
             - sr_ibs_eq_gemitt_zeta: final longitudinal equilibrium geometric emittance converged to, in [m].
     """
+    # ----------------------------------------------------------------------------------------------
+    # Check for SR equilibrium emittances, damping constants and partition numbers in the TwissTable
+    if None in (
+        getattr(twiss, "eq_gemitt_x", None),
+        getattr(twiss, "eq_gemitt_y", None),
+        getattr(twiss, "eq_gemitt_zeta", None),
+        getattr(twiss, "damping_constants_s", None),
+        getattr(twiss, "partition_numbers", None),
+    ):
+        LOGGER.error("Invalid TwissTable, does not have SR equilibrium properties. Did you configure radiation?")
+        raise AttributeError(
+            "The TwissTable must contain SR equilibrium emittances and damping constants. "
+            "Did you activate radiation and twiss with `eneloss_and_damping=True?`"
+        )
     # ----------------------------------------------------------------------------------------------
     # TODO: Perform check for valid value of emittance_constraint but no value of emittance coupling factor
     # ----------------------------------------------------------------------------------------------

--- a/xfields/ibs/_equilibrium.py
+++ b/xfields/ibs/_equilibrium.py
@@ -183,7 +183,7 @@ def compute_equilibrium_emittances_from_sr_and_ibs(
     and Intra-Beam Scattering until convergence to equilibrium values.
     The equilibrium state is determined by an iterative process which
     consists in computing the IBS growth rates and the emittance time
-    derivaties, then computing the emittances at the next time step,
+    derivatives, then computing the emittances at the next time step,
     potentially including the effect of transverse constraints, and
     checking for convergence. The convergence criteria can be chosen
     by the user.
@@ -195,6 +195,15 @@ def compute_equilibrium_emittances_from_sr_and_ibs(
     The impact from the longitudinal impedance (e.g. bunch lengthening
     or microwave instability) can be accounted for by specifying the RMS
     bunch length and momentum spread.
+
+    Notes
+    -----
+        It is required that radiation has been configured in the line,
+        and that the `TwissTable` holds information on the equilibrium
+        state from Synchrotron Radiation. This means calling first
+        `line.configure_radiation(model="mean")` and then the `.twiss()`
+        method with `eneloss_and_damping=True`. Please refer to the Twiss
+        user guide in the `xsuite` documentation for more information.
 
     Parameters
     ----------

--- a/xfields/ibs/_equilibrium.py
+++ b/xfields/ibs/_equilibrium.py
@@ -13,6 +13,7 @@ import numpy as np
 import xobjects as xo
 import xtrack as xt
 from numpy.typing import ArrayLike
+from xobjects.general import _print
 from xtrack import Table
 
 from xfields.ibs._analytical import IBSGrowthRates
@@ -379,9 +380,7 @@ def compute_equilibrium_emittances_from_sr_and_ibs(
         # --------------------------------------------------------------------------
         # Display estimated convergence progress if asked
         if verbose is True:
-            xo.general._print(
-                f"Iteration {iterations} - convergence = {100 * rtol / tolerance:.1f}%", end="\r"
-            )
+            _print(f"Iteration {iterations} - convergence = {100 * rtol / tolerance:.1f}%", end="\r")
         # --------------------------------------------------------------------------
         # Compute IBS growth rates and emittance derivatives (and unpack)
         ibs_growth_rates, emittance_derivatives = _ibs_rates_and_emittance_derivatives(
@@ -434,7 +433,7 @@ def compute_equilibrium_emittances_from_sr_and_ibs(
         iterations += 1
     # ----------------------------------------------------------------------------------------------
     # We have exited the loop, we have converged. Construct a Table with the results and return it
-    xo.general._print(f"Reached equilibrium with tolerance={tolerance:.2e} (vs rtol={rtol:.2e})")
+    _print(f"Reached equilibrium with tolerance={tolerance:.2e} (vs rtol={rtol:.2e})")
     result_table = Table(
         data={
             "time": np.cumsum(time_deltas),

--- a/xfields/ibs/_equilibrium.py
+++ b/xfields/ibs/_equilibrium.py
@@ -336,9 +336,11 @@ def compute_equilibrium_emittances_from_sr_and_ibs(
         emittance_x, emittance_y, emittance_z = initial_emittances
     # fmt: on
     # ---------------------------------------------------------------------------------------------
-    # Handle initial longitudinal emittance and potential effect of bunch lengthening
+    # Handle the potential longitudinal effects (bunch lengthening, microwave instability)
+    # First compute bunch length and momentum spread from longitudinal emittance (see xsuite twiss doc)
     sigma_zeta = (emittance_z * twiss.bets0) ** 0.5
     sigma_delta = (emittance_z / twiss.bets0) ** 0.5
+    # Now handle the scenario where the user wants to overwrite those
     if overwrite_sigma_zeta is not None:
         LOGGER.warning("'overwrite_sigma_zeta' is specified, make sure it remains consistent with 'initial_emittances'.")
         sigma_zeta = overwrite_sigma_zeta
@@ -346,6 +348,7 @@ def compute_equilibrium_emittances_from_sr_and_ibs(
         LOGGER.warning("'sigma_delta' is specified, make sure it remains consistent with 'initial_emittances'.")
         sigma_delta = overwrite_sigma_delta
     longitudinal_emittance_ratio = sigma_zeta / sigma_delta
+    # Recompute the longidutinal emittance if either bunch length or momentum spread was overwritten
     if overwrite_sigma_zeta is not None or overwrite_sigma_delta is not None:
         assert initial_emittances is not None, (
             "Input of 'overwrite_sigma_zeta' or 'overwrite_sigma_delta' provided, but "
@@ -437,6 +440,8 @@ def compute_equilibrium_emittances_from_sr_and_ibs(
             "gemitt_x": np.array(res_gemitt_x),
             "gemitt_y": np.array(res_gemitt_y),
             "gemitt_zeta": np.array(res_gemitt_zeta),
+            "sigma_zeta": np.sqrt(np.array(res_gemitt_zeta) * twiss.bets0) ,
+            "sigma_delta": np.sqrt(np.array(res_gemitt_zeta) / twiss.bets0),
             "Tx": np.array(T_x),
             "Ty": np.array(T_y),
             "Tz": np.array(T_z),


### PR DESCRIPTION
Touching the API this time, as well as some details here and there. Mostly public function.

Notable:
- Rename of public function to something very specific.
- Private function specifically requires geometrical emittances in its parameters (docstring updated). Those are also passed by the public function.
- The main docstring chunk for the public function has been rewritten / reworked.
- An empty string is not allowed for `emittance_constraint` to have no constraint, only passing `None`. This was done to simplify the checks.
- The public function returns an `xtrack.Table`. All columns are the previously returned lists (but as numpy arrays), and some used properties & final results are stored as well. Docstring updated.
- A check was added to ensure the required SR equilibrium attributes are present.
- A check was added for the validity of the provied `emittance_constraint` arg. If it is valid and `emittance_coupling_factor` is 0 a warning is logged.
- Some structure, comments and type hints were added.
- Commented out checks for individually provided emittances were added.

I have ran the script I put in #2 on your branch to check values. Due API differences (returning a `Table` etc) I have ran the following on my branch (you can check it is equivalent):
```python
import xtrack as xt
from scipy.constants import e

import xfields as xf

# Load line and build tracker
line = xt.Line.from_json("bessy3.json")
line.build_tracker()

# Prepare radiation mode and twiss
line.matrix_stability_tol = 1e-2
line.configure_radiation(model="mean")
line.compensate_radiation_energy_loss()
twiss = line.twiss(eneloss_and_damping=True)


# Compute emittance evolution to convergence
bunch_intensity = 1e-9 / e  # 1C bunch intensity
emittance_coupling_factor = 1
result = xf.ibs.compute_equilibrium_emittances_from_sr_and_ibs(
    twiss=twiss,
    formalism="Nagaitsev",  # default in seb's version
    total_beam_intensity=bunch_intensity,
    initial_emittances=None,
    emittance_coupling_factor=emittance_coupling_factor,
    emittance_constraint="coupling",
    rtol=1e-6,
)


# Checks prints
factor = 1 + emittance_coupling_factor * (twiss.partition_numbers[1] / twiss.partition_numbers[0])
# epsilon_x
print(
    result.sr_ibs_eq_gemitt_y,  # this is result.gemitt_x[-1]
    result.gemitt_x[0] / (1 - result.Tx[-1] / 2 / (twiss.damping_constants_s[0] * factor)),
)
# epsilon_y
print(
    result.sr_ibs_eq_gemitt_y,  # this is result.gemitt_y[-1]
    result.gemitt_y[0] / (1 - result.Tx[-1] / 2 / (twiss.damping_constants_s[0] * factor)),
)
# epsilon_z
print(
    result.sr_ibs_eq_gemitt_zeta,  # this is result.gemitt_zeta[-1]
    result.gemitt_zeta[0] / (1 - result.Tz[-1] / 2 / (twiss.damping_constants_s[2])),
)
```

Once more, results for both branches below:

| Converged Value  |      Your Branch      |       My Branch       |       Analytical      |
| ---------------- | --------------------- | --------------------- | --------------------- |
|     gemitt_x     | 8.449152285724216e-11 | 8.449152285724216e-11 | 8.450153188597292e-11 |
|     gemitt_y     | 8.449152285724216e-11 | 8.449152285724216e-11 | 8.450153188597292e-11 |
|    gemitt_zeta   | 4.517867740266872e-06 | 4.517867740266872e-06 | 4.519061552568138e-06 |